### PR TITLE
SunEdison's fixes for Issues #3, #6, and #7 (and more)

### DIFF
--- a/APL/APL.vcproj
+++ b/APL/APL.vcproj
@@ -305,6 +305,14 @@
 						RelativePath=".\PhysicalLayerAsyncTCPServer.h"
 						>
 					</File>
+					<File
+						RelativePath=".\TCPTypes.cpp"
+						>
+					</File>
+					<File
+						RelativePath=".\TCPTypes.h"
+						>
+					</File>
 				</Filter>
 			</Filter>
 			<Filter

--- a/APL/ASIOIncludes.h
+++ b/APL/ASIOIncludes.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/ASIOSerialHelpers.cpp
+++ b/APL/ASIOSerialHelpers.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/ASIOSerialHelpers.h
+++ b/APL/ASIOSerialHelpers.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/AsyncLayerInterfaces.cpp
+++ b/APL/AsyncLayerInterfaces.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/AsyncLayerInterfaces.h
+++ b/APL/AsyncLayerInterfaces.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/AsyncPhysLayerMonitor.cpp
+++ b/APL/AsyncPhysLayerMonitor.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/AsyncPhysLayerMonitor.h
+++ b/APL/AsyncPhysLayerMonitor.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/AsyncTaskBase.cpp
+++ b/APL/AsyncTaskBase.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -181,10 +181,10 @@ bool AsyncTaskBase::LessThanGroupLevel(const AsyncTaskBase* l, const AsyncTaskBa
 
 	/*
 	if(less_than) {
-		std::cout << r->Name() << " higher prioity than " << l->Name() << std::endl;
+		std::cout << r->Name() << " higher priority than " << l->Name() << std::endl;
 	}
 	else {
-		std::cout << l->Name() << " higher prioity than " << r->Name() << std::endl;
+		std::cout << l->Name() << " higher priority than " << r->Name() << std::endl;
 	}
 	*/
 

--- a/APL/AsyncTaskBase.h
+++ b/APL/AsyncTaskBase.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -103,10 +103,10 @@ class AsyncTaskBase : public ITask, private Uncopyable
 	/// @returns the completion status of the task
 	bool IsComplete() const { return mIsComplete; }
 
-	/// @return wether the task is expired
+	/// @return whether the task is expired
 	bool IsExpired() const { return mIsExpired; }
 
-	/// @return wether the task is running
+	/// @return whether the task is running
 	bool IsRunning() const { return mIsRunning; }
 
 	/// @returns max_date_time if the task is currently running or will not run again
@@ -117,7 +117,7 @@ class AsyncTaskBase : public ITask, private Uncopyable
 	std::string mName;						/// Every task has a name
 	bool mIsEnabled;						/// Tasks can be enabled or disabled
 	bool mIsComplete;						/// Every task has a flag that executes it's completion status
-	bool mIsExpired;						/// Indicate wether the time from the last UpdateTime call >= mNextRunTime
+	bool mIsExpired;						/// Indicate whether the time from the last UpdateTime call >= mNextRunTime
 	bool mIsRunning;						/// Every task has an execution status
 	int mPriority;							/// Every task has a pr
 	TaskHandler mHandler;					/// Every task has a handler for executing the task

--- a/APL/AsyncTaskContinuous.cpp
+++ b/APL/AsyncTaskContinuous.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/AsyncTaskContinuous.h
+++ b/APL/AsyncTaskContinuous.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -26,7 +26,7 @@ namespace apl {
 
 class AsyncTaskGroup;
 
-/** Continus asynchronous task, runs over and over as long as it is enabled.
+/** Continuous asynchronous task, runs over and over as long as it is enabled.
 */
 
 class AsyncTaskContinuous : public AsyncTaskBase
@@ -43,7 +43,7 @@ class AsyncTaskContinuous : public AsyncTaskBase
 		@param aPriority Tie break between non-dependent tasks. Lower is higher priority.
 		@param arCallback Bound function used for starting the asynchronous task.
 		@param apGroup Associated task group
-		@param arName Name associated with the tasak
+		@param arName Name associated with the task
 	*/
 	AsyncTaskContinuous(int aPriority, const TaskHandler& arCallback, AsyncTaskGroup* apGroup, const std::string& arName);
 

--- a/APL/AsyncTaskGroup.cpp
+++ b/APL/AsyncTaskGroup.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/AsyncTaskGroup.h
+++ b/APL/AsyncTaskGroup.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/AsyncTaskInterfaces.h
+++ b/APL/AsyncTaskInterfaces.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/AsyncTaskNonPeriodic.cpp
+++ b/APL/AsyncTaskNonPeriodic.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/AsyncTaskNonPeriodic.h
+++ b/APL/AsyncTaskNonPeriodic.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/AsyncTaskPeriodic.cpp
+++ b/APL/AsyncTaskPeriodic.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/AsyncTaskPeriodic.h
+++ b/APL/AsyncTaskPeriodic.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/AsyncTaskScheduler.cpp
+++ b/APL/AsyncTaskScheduler.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/AsyncTaskScheduler.h
+++ b/APL/AsyncTaskScheduler.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/BoundNotifier.h
+++ b/APL/BoundNotifier.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/CRC.cpp
+++ b/APL/CRC.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/CRC.h
+++ b/APL/CRC.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/CachedLogVariable.h
+++ b/APL/CachedLogVariable.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/ChangeBuffer.h
+++ b/APL/ChangeBuffer.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/CommandInterfaces.h
+++ b/APL/CommandInterfaces.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -25,7 +25,7 @@
 namespace apl
 {
 
-	/** Interface that defines how reponses are reported to an object.
+	/** Interface that defines how responses are reported to an object.
 	*/
 	class IResponseAcceptor
 	{
@@ -73,7 +73,7 @@ namespace apl
 
 
 	/**
-		Interface to the "command source" of the communications stack. When a command is recieved by the stack it
+		Interface to the "command source" of the communications stack. When a command is received by the stack it
 		will call Notify() on the passed in notifier. When Notify() is called (or on a schedule) the application
 		should call bool moreCommands = ExecuteCommand(&handler); until moreCommands is false, which means that all
 		of the commands available have been handled.

--- a/APL/CommandManager.cpp
+++ b/APL/CommandManager.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/CommandManager.h
+++ b/APL/CommandManager.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/CommandQueue.cpp
+++ b/APL/CommandQueue.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/CommandQueue.h
+++ b/APL/CommandQueue.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/CommandResponseQueue.cpp
+++ b/APL/CommandResponseQueue.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/CommandResponseQueue.h
+++ b/APL/CommandResponseQueue.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/CommandTypes.cpp
+++ b/APL/CommandTypes.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -214,7 +214,7 @@ namespace apl
 			if(mValue <= SingleFloat::Max && mValue >= SingleFloat::Min) return SPET_FLOAT;
 			return SPET_DOUBLE;
 		}
-		// if its not one of the auto types that means its been explictly set
+		// if its not one of the auto types that means its been explicitly set
 		// so we should use that type.
 		return mEncodingType;
 	}

--- a/APL/CommandTypes.h
+++ b/APL/CommandTypes.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -41,20 +41,20 @@ namespace apl
 	};
 
 	/**
-		When a command is recieved from a master the application sends a code to
-		indicate if it was successfull or if not what class of error was encountered.
+		When a command is received from a master the application sends a code to
+		indicate if it was successful or if not what class of error was encountered.
 		Each code has a description that indicates its customary meaning.
 	*/
 	enum CommandStatus
 	{
-		CS_SUCCESS = 0,			//!< command was successfully recieved and handled
-		CS_TIMEOUT = 1,			//!< command timedout before completing
+		CS_SUCCESS = 0,			//!< command was successfully received and handled
+		CS_TIMEOUT = 1,			//!< command timed out before completing
 		CS_NO_SELECT = 2,		//!< command requires being selected before operate, configuration issue
 		CS_FORMAT_ERROR = 3,	//!< bad control code or timing values
 		CS_NOT_SUPPORTED = 4,	//!< command is not implemented
-		CS_ALREADY_ACTIVE = 5,	//!< command is allready in progress or its allready in that mode
+		CS_ALREADY_ACTIVE = 5,	//!< command is already in progress or its already in that mode
 		CS_HARDWARE_ERROR = 6,	//!< something is stopping the command, often a local/remote interlock
-		CS_LOCAL = 7,			//!< the function goverened by the control is in local only control
+		CS_LOCAL = 7,			//!< the function governed by the control is in local only control
 		CS_TOO_MANY_OPS = 8,	//!< the command has been done too often and has been throttled
 		CS_NOT_AUTHORIZED = 9,	//!< the command was rejected because the device denied it or an RTU intercepted it
 		CS_UNDEFINED = 127		//!< 10 to 126 are currently reserved
@@ -77,7 +77,7 @@ namespace apl
 		CC_LATCH_ON = 0x03,		//!< a 'light-switch' moved to the ON position
 		CC_LATCH_OFF = 0x04,	//!< a 'light-switch' moved to the OFF position
 		CC_PULSE_CLOSE = 0x41,	//!< a 'doorbell' that rings while the button is depressed
-		CC_PULSE_TRIP = 0x81,	//!< a 'doorbell' that stops ringing (is normally on) while depreseed
+		CC_PULSE_TRIP = 0x81,	//!< a 'doorbell' that stops ringing (is normally on) while depressed
 		CC_UNDEFINED = 0xFF		//!< undefined command (used by DNP standard)
 	};
 
@@ -103,7 +103,7 @@ namespace apl
 
 	/**
 		Describes an incoming control request from the master. It is the applications responsibility to handle
-		the request and return an approiate status code.The PULSE_CLOSE and PULSE_TRIP ControlCodes require
+		the request and return an appropriate status code.The PULSE_CLOSE and PULSE_TRIP ControlCodes require
 		setting the mOnTimeMS,mOffTimeMS and mCount variables, otherwise just use the defaults.
 	*/
 	class BinaryOutput : public CommandRequest
@@ -147,7 +147,7 @@ namespace apl
 
 	/**
 		The object to represent a setpoint request from the master. Think of this like turning a
-		dial on the front of a machine to desired setting.  A setpoint is natively repersented as
+		dial on the front of a machine to desired setting.  A setpoint is natively represented as
 		a double but can be used to send both floating point and integer values. The key field is
 		mEncodingType which informs the protocol buffers how to treat and format the values. There
 		are smart defaults and behaviors to automatically determine the correct type of encoding

--- a/APL/Configure.h
+++ b/APL/Configure.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/CopyableBuffer.cpp
+++ b/APL/CopyableBuffer.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/CopyableBuffer.h
+++ b/APL/CopyableBuffer.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -32,7 +32,7 @@ namespace apl {
 class CopyableBuffer
 {
 	public:
-		/// Construct null bufer
+		/// Construct null buffer
 		CopyableBuffer();
 		/// Construct based on starting size of buffer
 		CopyableBuffer(size_t aSize);

--- a/APL/DataInterfaces.h
+++ b/APL/DataInterfaces.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -29,12 +29,12 @@ namespace apl
 /**
     A Transaction is a group of point Updates that occur together.
 	This is necessary because often times a single event will cause many values
-	to change and that should be handled as a group so the data isn't unecessarily
-	inconsistant. One example is a "master alarm" flag that is a summary of specific alarms,
-	if we couldn't group the updates toegether we might see the master alarm flag turn on
+	to change and that should be handled as a group so the data isn't unnecessarily
+	inconsistent. One example is a "master alarm" flag that is a summary of specific alarms,
+	if we couldn't group the updates together we might see the master alarm flag turn on
 	before any of the specific alarms had activated. Grouping the updates together also leads
-	to more effecient communications because large chunks of data get transmitted at a time and
-	we don't get into the pathelogical case of sending one update at a time.
+	to more efficient communications because large chunks of data get transmitted at a time and
+	we don't get into the pathological case of sending one update at a time.
 
 	\section Usage
 	\code
@@ -56,7 +56,7 @@ class ITransactable
 	ITransactable() : mInProgress(false) {}
 	virtual ~ITransactable(){}
 
-	// Enfore pre/post conditions on _Start/_End Operation
+	// Enforce pre/post conditions on _Start/_End Operation
 	void Start();
 	void End();
 
@@ -86,9 +86,9 @@ inline void ITransactable::End()
 
 /**
   This is a helper class that handles the starting and ending of the transaction
-  in an exeception safe manner. If we manually call Start, do some updates and
+  in an exception safe manner. If we manually call Start, do some updates and
   have an exception then its possible we wont end the transaction. By using this
-  transaction object the stack unwinding will guarentee that the transaction is
+  transaction object the stack unwinding will guarantee that the transaction is
   correctly cleaned up.
 */
 class Transaction{

--- a/APL/DataTypes.cpp
+++ b/APL/DataTypes.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/DataTypes.h
+++ b/APL/DataTypes.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -81,8 +81,8 @@ namespace apl
 	/**
 	  Base class shared by all of the DataPoint types. There are 5 major data types and they all have
 	  a value, timestamp and a quality field. The timestamp should reflect when the value was measured
-	  or calculated. The quality field should be set approriately depending on the data type. Each datatype
-	  has a its own defintion of the quality field that indicate specific conditions but all of the
+	  or calculated. The quality field should be set appropriately depending on the data type. Each datatype
+	  has a its own definition of the quality field that indicate specific conditions but all of the
 	  datatypes define an XX_ONLINE bit, that is the default "nominal" value. This quality field is not
 	  for applying alarming information, that needs to be done with Binaries or in other channels.
 	*/
@@ -219,7 +219,7 @@ namespace apl
 		{ return GetValue() == rhs.GetValue() && GetQuality() == rhs.GetQuality(); }
 
 		protected:
-		// IntDataPoints have seperate fields for quality and value
+		// IntDataPoints have separate fields for quality and value
 		//IntDataPoint(const IntDataPoint& arRHS);
 		TypedDataPoint(byte_t aQuality, DataTypes aType);
 		T mValue;
@@ -325,7 +325,7 @@ namespace apl
 	};
 
 	/**
-		Analogs are used for variable data points that usuually reflect a real world value.
+		Analogs are used for variable data points that usually reflect a real world value.
 		Good examples are current, voltage, sensor readouts, etc. Think of a speedometer gauge.
 	*/
 
@@ -382,8 +382,8 @@ namespace apl
 	};
 
 	/**
-		Descibes the last set value of the setpoint. Like the ControlStatus data type it is not
-		well supportted and its generally better practice to use an explict analog.
+		Describes the last set value of the setpoint. Like the ControlStatus data type it is not
+		well supported and its generally better practice to use an explicit analog.
 	*/
 	class SetpointStatus : public TypedDataPoint<double>
 	{

--- a/APL/EventLock.cpp
+++ b/APL/EventLock.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -37,7 +37,7 @@ void EventLock::RecordEventCode(const apl::int_64_t& arEvent)
 { this->mEvents |= arEvent; }
 
 
-//needs to be used only when we are allready locked on the object
+//needs to be used only when we are already locked on the object
 int_64_t EventLock::GetEvents(bool aClearSentEvents){
 	int_64_t temp = mEvents;
 	if(aClearSentEvents) mEvents = 0;

--- a/APL/EventLock.h
+++ b/APL/EventLock.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -34,7 +34,7 @@ class EventLock : public EventLockBase<int_64_t>
 	public:
 	EventLock();
 
-	//needs to be used only when we are allready locked on the object
+	//needs to be used only when we are already locked on the object
 	int_64_t GetEvents(bool aClearSentEvents = true);
 
 	static int_64_t Get64BitMask(size_t aShift);

--- a/APL/EventLockBase.h
+++ b/APL/EventLockBase.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/EventSet.h
+++ b/APL/EventSet.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/Exception.cpp
+++ b/APL/Exception.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/Exception.h
+++ b/APL/Exception.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -44,7 +44,7 @@ namespace apl {
 			int ErrorCode() const{ return this->mErrorCode; }
 			int SubCode() const{ return this->mSubCode; }
 
-			std::string GetErrorString() const; //returns a concatentated description of the exception
+			std::string GetErrorString() const; //returns a concatenated description of the exception
 
 		protected:
 
@@ -52,7 +52,7 @@ namespace apl {
 			int mErrorCode;
 			int mSubCode;
 
-			std::string mSource;	// The funciton or module that produced the exception
+			std::string mSource;	// The function or module that produced the exception
 			std::string mMessage;	// A textual description of the exception
 			std::string mWhat;
 

--- a/APL/FlexibleDataObserver.cpp
+++ b/APL/FlexibleDataObserver.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/FlexibleDataObserver.h
+++ b/APL/FlexibleDataObserver.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -30,7 +30,7 @@
 
 namespace apl
 {
-	/** Simple data obsever that stores the current value of anything it receives. SubjectBase implictly
+	/** Simple data observer that stores the current value of anything it receives. SubjectBase implicitly
 	notifies observers of any updates.
 
 	Check functionality allows it to be used for testing.

--- a/APL/IEventLock.h
+++ b/APL/IEventLock.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/IHandlerAsync.cpp
+++ b/APL/IHandlerAsync.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/IHandlerAsync.h
+++ b/APL/IHandlerAsync.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/INotifier.h
+++ b/APL/INotifier.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -22,10 +22,10 @@
 namespace apl
 {
 	/**
-		A generic interface that defines a notification function. Modeled loosly on a lock
+		A generic interface that defines a notification function. Modeled loosely on a lock
 		type interaction. Generally used for the multi-threaded observer pattern to indicate
 		that a shared _thread_safe_ object has had a change occur. The application then knows
-		that it needs to look at that shared object which it can do immediatley or at some point
+		that it needs to look at that shared object which it can do immediately or at some point
 		in the future (ie. when the "application" thread is ready).
 
 		It is critical to remember that the calls to Notify() can potentially come from any thread!

--- a/APL/IOService.cpp
+++ b/APL/IOService.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/IOService.h
+++ b/APL/IOService.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/IOServiceThread.cpp
+++ b/APL/IOServiceThread.cpp
@@ -36,7 +36,8 @@ class IOServiceExitException : public Exception
 		{}
 };
 
-IOServiceThread::IOServiceThread(boost::asio::io_service* apService) : 
+IOServiceThread::IOServiceThread(Logger* apLogger, boost::asio::io_service* apService) : 
+Loggable(apLogger),
 mpService(apService),
 mThread(this)
 {
@@ -65,7 +66,7 @@ void IOServiceThread::Run()
 		//clean exit		
 	}
 	catch(const std::exception& ex) {			
-		std::cout << ex.what() << std::endl;
+		LOG_BLOCK(LEV_ERROR, "IOService run() threw an exception: " << ex.what());
 	}
 
 }

--- a/APL/IOServiceThread.cpp
+++ b/APL/IOServiceThread.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/IOServiceThread.h
+++ b/APL/IOServiceThread.h
@@ -21,6 +21,7 @@
 
 #include "Thread.h"
 #include "TimerSourceASIO.h"
+#include "Loggable.h"
 
 namespace boost { namespace asio {
 	class io_service;
@@ -31,10 +32,10 @@ namespace apl {
 class Logger;
 class Timer;
 
-class IOServiceThread : public Threadable
+class IOServiceThread : public Threadable, public Loggable
 {
 	public:
-		IOServiceThread(boost::asio::io_service* apService);
+		IOServiceThread(Logger* apLogger, boost::asio::io_service* apService);
 
 		void Start() { mThread.Start(); }
 		void Stop();

--- a/APL/IOServiceThread.h
+++ b/APL/IOServiceThread.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/IPhysMonitor.h
+++ b/APL/IPhysMonitor.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/IPhysicalLayerAsync.h
+++ b/APL/IPhysicalLayerAsync.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -52,7 +52,7 @@ namespace apl{
 			virtual void AsyncOpen() = 0;
 
 			/** Starts a close operation. Callback is IHandlerAsync::OnLowerLayerDown.
-				Callback occurs after all Asynchronous operations have occured. If the user code
+				Callback occurs after all Asynchronous operations have occurred. If the user code
 				has an outstanding read or write, those handlers will not be called. */
 			virtual void AsyncClose() = 0;
 

--- a/APL/IPhysicalLayerSource.h
+++ b/APL/IPhysicalLayerSource.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/ISubject.h
+++ b/APL/ISubject.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/ITimeSource.h
+++ b/APL/ITimeSource.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/Lock.h
+++ b/APL/Lock.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/LockBase.cpp
+++ b/APL/LockBase.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/LockBase.h
+++ b/APL/LockBase.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/LockBoost.cpp
+++ b/APL/LockBoost.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -32,7 +32,7 @@ SigLock_Boost::SigLock_Boost() : mLockCount(0)
 SigLock_Boost::~SigLock_Boost()
 {
 #ifdef DEBUG_LOCKS
-	//make sure we havn;t missed a lock somewhere
+	//make sure we haven't missed a lock somewhere
 	assert(mLockPtr.get() == NULL);
 #endif
 	assert(mLockCount == 0);

--- a/APL/LockBoost.h
+++ b/APL/LockBoost.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/Log.cpp
+++ b/APL/Log.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/Log.h
+++ b/APL/Log.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/LogBase.h
+++ b/APL/LogBase.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/LogEntry.cpp
+++ b/APL/LogEntry.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/LogEntry.h
+++ b/APL/LogEntry.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/LogEntryCircularBuffer.cpp
+++ b/APL/LogEntryCircularBuffer.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/LogEntryCircularBuffer.h
+++ b/APL/LogEntryCircularBuffer.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/LogToFile.cpp
+++ b/APL/LogToFile.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/LogToFile.h
+++ b/APL/LogToFile.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -33,7 +33,7 @@
 
 namespace apl{
 
-/** Logging backend that uses a buffer and thread to do a non-blocking writeof all the log entries to a text file.
+/** Logging backend that uses a buffer and thread to do a non-blocking write of all the log entries to a text file.
 */
 class LogToFile: public LogEntryCircularBuffer, public Threadable
 {

--- a/APL/LogToStdio.cpp
+++ b/APL/LogToStdio.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/LogToStdio.h
+++ b/APL/LogToStdio.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/LogTypes.cpp
+++ b/APL/LogTypes.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/LogTypes.h
+++ b/APL/LogTypes.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/LogVar.h
+++ b/APL/LogVar.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/Loggable.cpp
+++ b/APL/Loggable.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/Loggable.h
+++ b/APL/Loggable.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/Logger.cpp
+++ b/APL/Logger.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/Logger.h
+++ b/APL/Logger.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/LowerLayerToPhysAdapter.cpp
+++ b/APL/LowerLayerToPhysAdapter.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/LowerLayerToPhysAdapter.h
+++ b/APL/LowerLayerToPhysAdapter.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/MetricBuffer.cpp
+++ b/APL/MetricBuffer.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/MetricBuffer.h
+++ b/APL/MetricBuffer.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/MultiplexingDataObserver.cpp
+++ b/APL/MultiplexingDataObserver.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/MultiplexingDataObserver.h
+++ b/APL/MultiplexingDataObserver.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/Notifier.h
+++ b/APL/Notifier.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PackingTemplates.h
+++ b/APL/PackingTemplates.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PackingUnpacking.cpp
+++ b/APL/PackingUnpacking.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PackingUnpacking.h
+++ b/APL/PackingUnpacking.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/Parsing.cpp
+++ b/APL/Parsing.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/Parsing.h
+++ b/APL/Parsing.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PhysLayerSettings.h
+++ b/APL/PhysLayerSettings.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PhysicalLayerAsyncASIO.h
+++ b/APL/PhysicalLayerAsyncASIO.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PhysicalLayerAsyncBase.cpp
+++ b/APL/PhysicalLayerAsyncBase.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PhysicalLayerAsyncBase.h
+++ b/APL/PhysicalLayerAsyncBase.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -83,7 +83,7 @@ namespace apl {
 			virtual void DoAsyncRead(byte_t*, size_t) = 0;
 			virtual void DoAsyncWrite(const byte_t*, size_t) = 0;
 
-			// These can be optionally overriden to do something more interesting, i.e. specific logging
+			// These can be optionally overridden to do something more interesting, i.e. specific logging
 			virtual void DoOpenSuccess() {}
 			virtual void DoOpenFailure() {}
 
@@ -101,7 +101,7 @@ namespace apl {
 			void OnReadCallback(const boost::system::error_code& arError, byte_t*, size_t aSize);
 			void OnWriteCallback(const boost::system::error_code& arError, size_t aSize);
 
-			/// "user" object that recieves the callbacks
+			/// "user" object that receives the callbacks
 			IHandlerAsync* mpHandler;
 
 			/// State object that tracks the activities of the class, state pattern too heavy

--- a/APL/PhysicalLayerAsyncBaseTCP.cpp
+++ b/APL/PhysicalLayerAsyncBaseTCP.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -53,7 +53,7 @@ void PhysicalLayerAsyncBaseTCP::DoClose()
 void PhysicalLayerAsyncBaseTCP::DoOpenSuccess()
 {
 	//mSocket.set_option(ip::tcp::no_delay(true));
-	LOG_BLOCK(LEV_INFO, "Successful conneciton");
+	LOG_BLOCK(LEV_INFO, "Successful connection");
 }
 
 void PhysicalLayerAsyncBaseTCP::DoAsyncRead(byte_t* apBuffer, size_t aMaxBytes)
@@ -70,7 +70,7 @@ void PhysicalLayerAsyncBaseTCP::DoAsyncWrite(const byte_t* apBuffer, size_t aNum
 
 void PhysicalLayerAsyncBaseTCP::DoOpenFailure()
 {
-	LOG_BLOCK(LEV_INFO, "Failed socket open, reclosing");
+	LOG_BLOCK(LEV_INFO, "Failed socket open, re-closing");
 	DoClose();
 }
 

--- a/APL/PhysicalLayerAsyncBaseTCP.h
+++ b/APL/PhysicalLayerAsyncBaseTCP.h
@@ -20,6 +20,7 @@
 #define __PHYSICAL_LAYER_ASYNC_BASE_TCP_H_
 
 #include "PhysicalLayerAsyncASIO.h"
+#include "TCPTypes.h"
 #include <boost/asio/ip/tcp.hpp>
 #include <memory>
 
@@ -31,7 +32,7 @@ namespace apl {
 	class PhysicalLayerAsyncBaseTCP : public PhysicalLayerAsyncASIO
 	{
 		public:
-			PhysicalLayerAsyncBaseTCP(Logger*, boost::asio::io_service* apIOService);
+			PhysicalLayerAsyncBaseTCP(Logger*, boost::asio::io_service* apIOService, TCPSettings aTcp);
 
 			virtual ~PhysicalLayerAsyncBaseTCP(){}
 
@@ -44,6 +45,7 @@ namespace apl {
 
 		protected:
 			boost::asio::ip::tcp::socket mSocket;
+                        TCPSettings mTcp;
 	};
 }
 

--- a/APL/PhysicalLayerAsyncBaseTCP.h
+++ b/APL/PhysicalLayerAsyncBaseTCP.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PhysicalLayerAsyncSerial.cpp
+++ b/APL/PhysicalLayerAsyncSerial.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PhysicalLayerAsyncSerial.h
+++ b/APL/PhysicalLayerAsyncSerial.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PhysicalLayerAsyncTCPClient.cpp
+++ b/APL/PhysicalLayerAsyncTCPClient.cpp
@@ -36,12 +36,9 @@ namespace apl {
 PhysicalLayerAsyncTCPClient::PhysicalLayerAsyncTCPClient(
 	Logger* apLogger,
 	boost::asio::io_service* apIOService,
-	const std::string& arAddress,
-	uint_16_t aPort) :
+	TCPSettings aTcp) :
 	
-	PhysicalLayerAsyncBaseTCP(apLogger, apIOService),
-	mAddr(arAddress),
-	mPort(aPort)
+	PhysicalLayerAsyncBaseTCP(apLogger, apIOService, aTcp)
 {
 
 }
@@ -51,11 +48,11 @@ void PhysicalLayerAsyncTCPClient::DoOpen()
 {
 	ip::address_v4 address;
 	boost::system::error_code ec;
-	string ipstring(mAddr);
+	string ipstring(mTcp.mAddress);
 	address = address.from_string(ipstring, ec);
 	if(ec) throw ArgumentException(LOCATION, "string Address: " + ipstring + " is invalid");
 	
-	ip::tcp::endpoint serverEndpoint(address, mPort);
+	ip::tcp::endpoint serverEndpoint(address, mTcp.mPort);
 
 	mSocket.async_connect(serverEndpoint, boost::bind(&PhysicalLayerAsyncTCPClient::OnOpenCallback, this, placeholders::error));
 }

--- a/APL/PhysicalLayerAsyncTCPClient.cpp
+++ b/APL/PhysicalLayerAsyncTCPClient.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PhysicalLayerAsyncTCPClient.h
+++ b/APL/PhysicalLayerAsyncTCPClient.h
@@ -26,14 +26,10 @@ namespace apl {
 	class PhysicalLayerAsyncTCPClient : public PhysicalLayerAsyncBaseTCP
 	{
 		public:
-			PhysicalLayerAsyncTCPClient(Logger*, boost::asio::io_service* apIOService, const std::string&, uint_16_t aPort);
+			PhysicalLayerAsyncTCPClient(Logger*, boost::asio::io_service* apIOService, TCPSettings aTcp);
 
 			/* Implement the remaining actions */
 			void DoOpen();
-
-		private:
-			std::string mAddr;
-			uint_16_t mPort;
 	};
 }
 

--- a/APL/PhysicalLayerAsyncTCPClient.h
+++ b/APL/PhysicalLayerAsyncTCPClient.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PhysicalLayerAsyncTCPServer.cpp
+++ b/APL/PhysicalLayerAsyncTCPServer.cpp
@@ -33,15 +33,15 @@ using namespace std;
 
 namespace apl {
 
-PhysicalLayerAsyncTCPServer::PhysicalLayerAsyncTCPServer(Logger* apLogger, io_service* apIOService, const std::string& arEndpoint, uint_16_t aPort) :
-PhysicalLayerAsyncBaseTCP(apLogger, apIOService),
-mEndpoint(ip::tcp::v4(), aPort),
+PhysicalLayerAsyncTCPServer::PhysicalLayerAsyncTCPServer(Logger* apLogger, io_service* apIOService, TCPSettings aTcp) :
+PhysicalLayerAsyncBaseTCP(apLogger, apIOService, aTcp),
+mEndpoint(ip::tcp::v4(), aTcp.mPort),
 mAcceptor(*apIOService)
 {
 	//set the endpoint's address
 	boost::system::error_code ec;
-	ip::address_v4 addr = ip::address_v4::from_string(arEndpoint, ec);	
-	if(ec) throw ArgumentException(LOCATION, "endpoint: " + arEndpoint + " is invalid ");	
+	ip::address_v4 addr = ip::address_v4::from_string(aTcp.mAddress, ec);	
+	if(ec) throw ArgumentException(LOCATION, "endpoint: " + aTcp.mAddress + " is invalid ");	
 	mEndpoint.address(addr);
 }
 
@@ -62,7 +62,7 @@ void PhysicalLayerAsyncTCPServer::DoOpen()
 		if(ec) throw Exception(LOCATION, ec.message());
 	}
 	
-	mAcceptor.async_accept(mSocket, mEndpoint, boost::bind(&PhysicalLayerAsyncTCPServer::OnOpenCallback, this, placeholders::error));
+	mAcceptor.async_accept(mSocket, boost::bind(&PhysicalLayerAsyncTCPServer::OnOpenCallback, this, placeholders::error));
 }
 
 void PhysicalLayerAsyncTCPServer::DoOpeningClose()

--- a/APL/PhysicalLayerAsyncTCPServer.cpp
+++ b/APL/PhysicalLayerAsyncTCPServer.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PhysicalLayerAsyncTCPServer.h
+++ b/APL/PhysicalLayerAsyncTCPServer.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -29,7 +29,7 @@ namespace apl {
 		public:			
 			PhysicalLayerAsyncTCPServer(Logger*, boost::asio::io_service* apIOService, const std::string& arEndpoint, uint_16_t aPort);
 
-			/* Implement the remainging actions */
+			/* Implement the remaining actions */
 			void DoOpen();
 			void DoOpeningClose(); //override this to cancel the acceptor instead of the socket
 

--- a/APL/PhysicalLayerFactory.cpp
+++ b/APL/PhysicalLayerFactory.cpp
@@ -34,14 +34,14 @@ namespace apl {
 		return boost::bind(&PhysicalLayerFactory::FGetSerialAsync, s, _2, _1);
 	}
 
-	IPhysicalLayerAsyncFactory PhysicalLayerFactory :: GetTCPClientAsync(std::string aAddress, uint_16_t aPort)
+	IPhysicalLayerAsyncFactory PhysicalLayerFactory :: GetTCPClientAsync(TCPSettings aTcp)
 	{
-		return boost::bind(&PhysicalLayerFactory::FGetTCPClientAsync, aAddress, aPort, _2, _1);
+		return boost::bind(&PhysicalLayerFactory::FGetTCPClientAsync, aTcp, _2, _1);
 	}
 	
-	IPhysicalLayerAsyncFactory PhysicalLayerFactory :: GetTCPServerAsync(std::string aEndpoint, uint_16_t aPort)
+	IPhysicalLayerAsyncFactory PhysicalLayerFactory :: GetTCPServerAsync(TCPSettings aTcp)
 	{
-		return boost::bind(&PhysicalLayerFactory::FGetTCPServerAsync, aEndpoint, aPort, _2, _1);
+		return boost::bind(&PhysicalLayerFactory::FGetTCPServerAsync, aTcp, _2, _1);
 	}
 	
 	IPhysicalLayerAsync* PhysicalLayerFactory :: FGetSerialAsync(SerialSettings s, boost::asio::io_service* apSrv, Logger* apLogger)
@@ -49,14 +49,14 @@ namespace apl {
 		return new PhysicalLayerAsyncSerial(apLogger, apSrv, s);
 	}
 	
-	IPhysicalLayerAsync* PhysicalLayerFactory :: FGetTCPClientAsync(std::string aAddress, uint_16_t aPort, boost::asio::io_service* apSrv, Logger* apLogger)
+	IPhysicalLayerAsync* PhysicalLayerFactory :: FGetTCPClientAsync(TCPSettings aTcp, boost::asio::io_service* apSrv, Logger* apLogger)
 	{
-		return new PhysicalLayerAsyncTCPClient(apLogger, apSrv, aAddress, aPort);
+		return new PhysicalLayerAsyncTCPClient(apLogger, apSrv, aTcp);
 	}
 	
-	IPhysicalLayerAsync* PhysicalLayerFactory :: FGetTCPServerAsync(std::string aEndpoint, uint_16_t aPort, boost::asio::io_service* apSrv, Logger* apLogger)
+	IPhysicalLayerAsync* PhysicalLayerFactory :: FGetTCPServerAsync(TCPSettings aTcp, boost::asio::io_service* apSrv, Logger* apLogger)
 	{
-		return new PhysicalLayerAsyncTCPServer(apLogger, apSrv, aEndpoint, aPort);
+		return new PhysicalLayerAsyncTCPServer(apLogger, apSrv, aTcp);
 	}
 
 }

--- a/APL/PhysicalLayerFactory.cpp
+++ b/APL/PhysicalLayerFactory.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PhysicalLayerFactory.h
+++ b/APL/PhysicalLayerFactory.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PhysicalLayerFunctors.h
+++ b/APL/PhysicalLayerFunctors.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PhysicalLayerInstance.cpp
+++ b/APL/PhysicalLayerInstance.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PhysicalLayerInstance.h
+++ b/APL/PhysicalLayerInstance.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PhysicalLayerManager.cpp
+++ b/APL/PhysicalLayerManager.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PhysicalLayerManager.cpp
+++ b/APL/PhysicalLayerManager.cpp
@@ -55,16 +55,16 @@ namespace apl
 		mSettingsMap.erase(arName);
 	}
 
-	void PhysicalLayerManager ::AddTCPClient(const std::string& arName, PhysLayerSettings s, const std::string& arAddr, uint_16_t aPort)
+	void PhysicalLayerManager ::AddTCPClient(const std::string& arName, PhysLayerSettings s, TCPSettings aTcp)
 	{		
-		IPhysicalLayerAsyncFactory fac = PhysicalLayerFactory::GetTCPClientAsync(arAddr, aPort);
+		IPhysicalLayerAsyncFactory fac = PhysicalLayerFactory::GetTCPClientAsync(aTcp);
 		PhysLayerInstance pli(fac);
 		this->AddLayer(arName, s, pli);
 	}
 
-	void PhysicalLayerManager ::AddTCPServer(const std::string& arName, PhysLayerSettings s, const std::string& arEndpoint, uint_16_t aPort)
+	void PhysicalLayerManager ::AddTCPServer(const std::string& arName, PhysLayerSettings s, TCPSettings aTcp)
 	{		
-		IPhysicalLayerAsyncFactory fac = PhysicalLayerFactory::GetTCPServerAsync(arEndpoint, aPort);
+		IPhysicalLayerAsyncFactory fac = PhysicalLayerFactory::GetTCPServerAsync(aTcp);
 		PhysLayerInstance pli(fac);
 		this->AddLayer(arName, s, pli);
 	}

--- a/APL/PhysicalLayerManager.h
+++ b/APL/PhysicalLayerManager.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -35,7 +35,7 @@ namespace apl
 			PhysicalLayerManager(Logger*, bool aOwnsLayers = true);
 			virtual ~PhysicalLayerManager();
 
-			//function for manually adding entires
+			//function for manually adding entries
 
 			void AddTCPClient(const std::string& arName, PhysLayerSettings, const std::string& arAddr, uint_16_t aPort);
 			void AddTCPServer(const std::string& arName, PhysLayerSettings, const std::string& arEndpoint, uint_16_t aPort);

--- a/APL/PhysicalLayerManager.h
+++ b/APL/PhysicalLayerManager.h
@@ -22,6 +22,7 @@
 
 #include "PhysicalLayerMap.h"
 #include "SerialTypes.h"
+#include "TCPTypes.h"
 
 namespace apl
 {
@@ -37,8 +38,8 @@ namespace apl
 
 			//function for manually adding entries
 
-			void AddTCPClient(const std::string& arName, PhysLayerSettings, const std::string& arAddr, uint_16_t aPort);
-			void AddTCPServer(const std::string& arName, PhysLayerSettings, const std::string& arEndpoint, uint_16_t aPort);
+			void AddTCPClient(const std::string& arName, PhysLayerSettings, TCPSettings);
+			void AddTCPServer(const std::string& arName, PhysLayerSettings, TCPSettings);
 			void AddSerial(const std::string& arName, PhysLayerSettings, SerialSettings);
 
 			/// Removes a physical layer and deletes it if the manager has ownership.

--- a/APL/PhysicalLayerMap.cpp
+++ b/APL/PhysicalLayerMap.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PhysicalLayerMap.h
+++ b/APL/PhysicalLayerMap.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PostingNotifier.cpp
+++ b/APL/PostingNotifier.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PostingNotifier.h
+++ b/APL/PostingNotifier.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PostingNotifierSource.cpp
+++ b/APL/PostingNotifierSource.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/PostingNotifierSource.h
+++ b/APL/PostingNotifierSource.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/ProtocolUtil.cpp
+++ b/APL/ProtocolUtil.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -20,7 +20,7 @@
 
 namespace apl {
 
-/// Given a buffer and max packet size, calculcate the 
+/// Given a buffer and max packet size, calculate the 
 /// maximum number of packets the buffer can hold
 size_t CalcMaxPackets(size_t aBuffer, size_t aPayload)
 {

--- a/APL/ProtocolUtil.h
+++ b/APL/ProtocolUtil.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -24,12 +24,12 @@
 
 namespace apl {
 
-/// Given a buffer and max packet size, calculcate the
+/// Given a buffer and max packet size, calculate the
 /// maximum number of packets the buffer can hold
 size_t CalcMaxPackets(size_t aBuffer, size_t aPayload);
 
 
-/// Given a buffer and max packet size, calculcate the
+/// Given a buffer and max packet size, calculate the
 /// size of the last packet.
 size_t CalcLastPacketSize(size_t aBuffer, size_t aPayload);
 

--- a/APL/QualityConverter.cpp
+++ b/APL/QualityConverter.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/QualityConverter.h
+++ b/APL/QualityConverter.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/QualityMasks.h
+++ b/APL/QualityMasks.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -31,7 +31,7 @@ namespace apl {
 		BQ_COMM_LOST = 0x04,			//!< this means the communication has been lost with the source of the data (after establishing contact)
 		BQ_REMOTE_FORCED_DATA = 0x08,	//!< the value is being forced to a "fake" value somewhere in the system
 		BQ_LOCAL_FORCED_DATA = 0x10,	//!< the value is being forced to a "fake" value on the original device
-		BQ_CHATTER_FILTER = 0x20,		//!< set when the value is osciallating very quickly and some events are being suppressed
+		BQ_CHATTER_FILTER = 0x20,		//!< set when the value is oscillating very quickly and some events are being suppressed
 		BQ_RESERVED = 0x40,				//!< reserved
 		BQ_STATE = 0x80,				//!< the actual value of the binary
 	};
@@ -47,7 +47,7 @@ namespace apl {
 		AQ_REMOTE_FORCED_DATA = 0x08,
 		AQ_LOCAL_FORCED_DATA = 0x10,
 		AQ_OVERRANGE = 0x20,			//!< if a hardware input etc. is out of range and we are using a place holder value
-		AQ_REFERENCE_CHECK = 0x40,		//!< meaning we may have lost calibration or refrence voltage so readings are questionable
+		AQ_REFERENCE_CHECK = 0x40,		//!< meaning we may have lost calibration or reference voltage so readings are questionable
 		AQ_RESERVED = 0x80
 	};
 
@@ -61,7 +61,7 @@ namespace apl {
 		CQ_COMM_LOST = 0x04,
 		CQ_REMOTE_FORCED_DATA = 0x08,
 		CQ_LOCAL_FORCED_DATA = 0x10,
-		CQ_ROLLOVER = 0x20,				//!< used to indicate that the counter filled up and rolledover, cleared automatically after reading
+		CQ_ROLLOVER = 0x20,				//!< used to indicate that the counter filled up and rolled over, cleared automatically after reading
 		CQ_DISCONTINUITY = 0x40,		//!< indicates an unusual change in value
 		CQ_RESERVED = 0x80
 	};

--- a/APL/QueueingFDO.h
+++ b/APL/QueueingFDO.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/SerialTypes.h
+++ b/APL/SerialTypes.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/ShiftableBuffer.cpp
+++ b/APL/ShiftableBuffer.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/ShiftableBuffer.h
+++ b/APL/ShiftableBuffer.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -80,7 +80,7 @@ class ShiftableBuffer
 
 	/**
 		Searches the read subsequence for a pattern. If a match is found, the reader is advanced to the beginning of the match.
-		If a partial match is found at the end of the read subsequence, the partial match is perserved.
+		If a partial match is found at the end of the read subsequence, the partial match is preserved.
 
 		i.e. if the pattern is {CBC} and the unread buffer is {AACB}, the unread buffer after the sync
 		will be {CB}.

--- a/APL/Singleton.h
+++ b/APL/Singleton.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/SubjectBase.h
+++ b/APL/SubjectBase.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/SyncVar.h
+++ b/APL/SyncVar.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/TCPTypes.cpp
+++ b/APL/TCPTypes.cpp
@@ -1,4 +1,4 @@
-//
+// 
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
@@ -6,40 +6,35 @@
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
-//
+// 
 // http://www.apache.org/licenses/LICENSE-2.0
-//
+//  
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
-#ifndef __PHYSICAL_LAYER_ASYNC_TCP_SERVER_H_
-#define __PHYSICAL_LAYER_ASYNC_TCP_SERVER_H_
+// 
 
-#include "PhysicalLayerAsyncBaseTCP.h"
-#include <boost/asio/ip/tcp.hpp>
+#include "TCPTypes.h"
 
 namespace apl {
 
-	class PhysicalLayerAsyncTCPServer : public PhysicalLayerAsyncBaseTCP
-	{
-		public:			
-			PhysicalLayerAsyncTCPServer(Logger*, boost::asio::io_service* apIOService, TCPSettings aTcp);
-
-			/* Implement the remaining actions */
-			void DoOpen();
-			void DoOpeningClose(); //override this to cancel the acceptor instead of the socket
-
-		private:
-			/* This object appears to be used referentially
-			as in the asynchronous code as having it disappear from the stack was causing a stack corruption. */
-			boost::asio::ip::tcp::endpoint mEndpoint;
-			boost::asio::ip::tcp::acceptor mAcceptor;
-
-	};
+TCPSettings::TCPSettings(const std::string aAddress,
+	const uint_16_t aPort,
+	const bool aEnableKeepalive,
+	const int aKeepaliveTime,
+	const int aKeepaliveInterval,
+	const int aKeepaliveProbes) :
+mAddress(aAddress),
+mPort(aPort),
+mEnableKeepalive(aEnableKeepalive),
+mKeepaliveTime(aKeepaliveTime),
+mKeepaliveInterval(aKeepaliveInterval),
+mKeepaliveProbes(aKeepaliveProbes)
+{
 }
 
-#endif
+}
+

--- a/APL/TCPTypes.h
+++ b/APL/TCPTypes.h
@@ -16,32 +16,33 @@
 // specific language governing permissions and limitations
 // under the License.
 //
-#ifndef _PHYSICAL_LAYER_FACTORY_H_
-#define _PHYSICAL_LAYER_FACTORY_H_
+#ifndef __TCP_TYPES_H_
+#define __TCP_TYPES_H_
 
-
-#include "SerialTypes.h"
-#include "TCPTypes.h"
 #include "Types.h"
-#include "Exception.h"
-#include "PhysicalLayerFunctors.h"
-#include <map>
 
-namespace apl{
+#include <string>
 
-	class PhysicalLayerFactory
+namespace apl {
+
+	struct TCPSettings
 	{
-	public:
+		TCPSettings(const std::string aAddress,
+			const uint_16_t aPort,
+			const bool aEnableKeepalive = false,
+			const int aKeepaliveTime = 0,
+			const int aKeepaliveInterval = 0,
+			const int aKeepaliveProbes = 0);
 
-		static IPhysicalLayerAsyncFactory GetSerialAsync(SerialSettings s);
-		static IPhysicalLayerAsyncFactory GetTCPClientAsync(TCPSettings aTcp);
-		static IPhysicalLayerAsyncFactory GetTCPServerAsync(TCPSettings aTcp);
-
-		//normal factory functions
-		static IPhysicalLayerAsync* FGetSerialAsync(SerialSettings s, boost::asio::io_service* apSrv, Logger* apLogger);
-		static IPhysicalLayerAsync* FGetTCPClientAsync(TCPSettings aTcp, boost::asio::io_service* apSrv, Logger* apLogger);
-		static IPhysicalLayerAsync* FGetTCPServerAsync(TCPSettings aTcp, boost::asio::io_service* apSrv, Logger* apLogger);
+		std::string mAddress;
+		uint_16_t mPort;
+		bool mEnableKeepalive;
+		int mKeepaliveTime;
+		int mKeepaliveInterval;
+		int mKeepaliveProbes;
 	};
+
 }
 
 #endif
+

--- a/APL/Thread.h
+++ b/APL/Thread.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/ThreadBase.cpp
+++ b/APL/ThreadBase.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/ThreadBase.h
+++ b/APL/ThreadBase.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -37,7 +37,7 @@ class ThreadBase
 
 	protected:
 
-		//pointer to obejct that conforms to the IThreadable interface
+		//pointer to object that conforms to the IThreadable interface
 		Threadable* mpThreadable;
 
 		bool mIsExitRequested;

--- a/APL/ThreadBoost.cpp
+++ b/APL/ThreadBoost.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/ThreadBoost.h
+++ b/APL/ThreadBoost.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/Threadable.cpp
+++ b/APL/Threadable.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/Threadable.h
+++ b/APL/Threadable.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -43,7 +43,7 @@ class Threadable
 		///allows a client to see if the thread is running
 		inline bool IsRunning() { return mIsRunning; }
 
-		///allows a client to see fi the thread has been "canceled"
+		///allows a client to see if the thread has been "canceled"
 		inline bool IsExitRequested(){return mIsExitRequested;}
 
 		void ResetStopRequest();

--- a/APL/TimeBase.cpp
+++ b/APL/TimeBase.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/TimeBase.h
+++ b/APL/TimeBase.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/TimeBoost.cpp
+++ b/APL/TimeBoost.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/TimeBoost.h
+++ b/APL/TimeBoost.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/TimeSource.cpp
+++ b/APL/TimeSource.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/TimeSource.h
+++ b/APL/TimeSource.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/TimeTypes.h
+++ b/APL/TimeTypes.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/Timeout.cpp
+++ b/APL/Timeout.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/Timeout.h
+++ b/APL/Timeout.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -27,7 +27,7 @@ namespace apl{
 	/// Use this class to simplify writing do loops with a timeout
 	/// it minimizes the number of calls to get datetime and allows
 	/// us to easily replace the implementation later if we find an
-	/// even more effecient way to implement the timeout checking.
+	/// even more efficient way to implement the timeout checking.
 	///
 	/// Intended Usage:
   ///
@@ -40,14 +40,14 @@ namespace apl{
 	///		if(success) return or break;
 	///
 	///		//or go back around the loop, the next call to
-	///		//remaining will be guarnteed to be > 0
+	///		//remaining will be guaranteed to be > 0
 	/// }while(!to.IsExpired());
 	class Timeout{
 	public:
-		/// constuctor, timeout will expire this many mills in the future
+		/// constructor, timeout will expire this many mills in the future
 		Timeout(apl::millis_t aTimeout);
 
-		/// updates the remaing time (by default) and returns whether its expired
+		/// updates the remaining time (by default) and returns whether its expired
 		bool IsExpired(bool aUpdateRemaining = true);
 
 		/// returns how much time is left (by default since the last IsExpired() call)

--- a/APL/TimerASIO.cpp
+++ b/APL/TimerASIO.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/TimerASIO.h
+++ b/APL/TimerASIO.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -28,7 +28,7 @@ namespace apl {
 /**
  * This is a wrapper for ASIO timers that are used to post events
  * on a queue. Events can be posted for immediate consumption or
- * some time in the future. Events can be consumbed by the posting
+ * some time in the future. Events can be consumed by the posting
  * thread or another thread.
  *
  * @section Class Goals

--- a/APL/TimerInterfaces.h
+++ b/APL/TimerInterfaces.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -30,7 +30,7 @@ namespace apl {
 /**
  * This is a wrapper for ASIO timers that are used to post events
  * on a queue. Events can be posted for immediate consumption or
- * some time in the future. Events can be consumbed by the posting
+ * some time in the future. Events can be consumed by the posting
  * thread or another thread.
  *
  * @section Class Goals
@@ -56,7 +56,7 @@ typedef boost::function<void ()> ExpirationHandler;
 
 /**
  * Interface for posting events to a queue.  Events can be posted for
- * immediate consumption or some time in the future.  Events can be consumbed
+ * immediate consumption or some time in the future.  Events can be consumed
  * by the posting thread or another thread.
  *
  * @section Usage

--- a/APL/TimerSourceASIO.cpp
+++ b/APL/TimerSourceASIO.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/TimerSourceASIO.h
+++ b/APL/TimerSourceASIO.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/TimingTools.cpp
+++ b/APL/TimingTools.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/TimingTools.h
+++ b/APL/TimingTools.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/ToHex.cpp
+++ b/APL/ToHex.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/ToHex.h
+++ b/APL/ToHex.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/Types.h
+++ b/APL/Types.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -65,7 +65,7 @@ namespace apl
 	};
 
 	//this is some c++ trickery to make sure that we get strong
-	//typesaftey on the 2 different types of timestamp
+	//type safety on the 2 different types of timestamp
 	typedef TimeStamp_t_Explicit TimeStamp_t;
 	typedef UTCTimeStamp_t_Explicit UTCTimeStamp_t;
 

--- a/APL/Uncopyable.h
+++ b/APL/Uncopyable.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/Util.cpp
+++ b/APL/Util.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APL/Util.h
+++ b/APL/Util.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/AsyncTestObject.cpp
+++ b/APLTestTools/AsyncTestObject.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/AsyncTestObject.h
+++ b/APLTestTools/AsyncTestObject.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/AsyncTestObjectASIO.cpp
+++ b/APLTestTools/AsyncTestObjectASIO.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/AsyncTestObjectASIO.h
+++ b/APLTestTools/AsyncTestObjectASIO.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/BufferHelpers.cpp
+++ b/APLTestTools/BufferHelpers.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/BufferHelpers.h
+++ b/APLTestTools/BufferHelpers.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/BufferTestObject.cpp
+++ b/APLTestTools/BufferTestObject.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/BufferTestObject.h
+++ b/APLTestTools/BufferTestObject.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/LogTester.cpp
+++ b/APLTestTools/LogTester.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/LogTester.h
+++ b/APLTestTools/LogTester.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/LoopbackPhysicalLayerAsync.cpp
+++ b/APLTestTools/LoopbackPhysicalLayerAsync.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/LoopbackPhysicalLayerAsync.h
+++ b/APLTestTools/LoopbackPhysicalLayerAsync.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/MockCommandAcceptor.h
+++ b/APLTestTools/MockCommandAcceptor.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/MockCommandHandler.h
+++ b/APLTestTools/MockCommandHandler.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/MockLowerLayer.cpp
+++ b/APLTestTools/MockLowerLayer.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/MockLowerLayer.h
+++ b/APLTestTools/MockLowerLayer.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/MockNodeSaver.h
+++ b/APLTestTools/MockNodeSaver.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/MockNotifier.h
+++ b/APLTestTools/MockNotifier.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/MockPhysicalLayerAsync.cpp
+++ b/APLTestTools/MockPhysicalLayerAsync.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/MockPhysicalLayerAsync.h
+++ b/APLTestTools/MockPhysicalLayerAsync.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/MockPhysicalLayerAsyncTS.cpp
+++ b/APLTestTools/MockPhysicalLayerAsyncTS.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/MockPhysicalLayerAsyncTS.h
+++ b/APLTestTools/MockPhysicalLayerAsyncTS.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/MockResponseAcceptor.cpp
+++ b/APLTestTools/MockResponseAcceptor.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/MockResponseAcceptor.h
+++ b/APLTestTools/MockResponseAcceptor.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/MockTimerSource.cpp
+++ b/APLTestTools/MockTimerSource.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/MockTimerSource.h
+++ b/APLTestTools/MockTimerSource.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/MockUpperLayer.cpp
+++ b/APLTestTools/MockUpperLayer.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/MockUpperLayer.h
+++ b/APLTestTools/MockUpperLayer.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/TestHelpers.h
+++ b/APLTestTools/TestHelpers.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLTestTools/TestTypedefs.h
+++ b/APLTestTools/TestTypedefs.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLXML/INodeSaver.h
+++ b/APLXML/INodeSaver.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLXML/PhysicalLayerManagerXML.cpp
+++ b/APLXML/PhysicalLayerManagerXML.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLXML/PhysicalLayerManagerXML.h
+++ b/APLXML/PhysicalLayerManagerXML.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLXML/PhysicalLayerXMLFactory.cpp
+++ b/APLXML/PhysicalLayerXMLFactory.cpp
@@ -47,14 +47,14 @@ namespace apl{ namespace xml{
 
 	IPhysicalLayerAsyncFactory PhysicalLayerXMLFactory :: GetAsync(const APLXML_Base::TCPClient_t* apCfg)
 	{
-		uint_16_t port = boost::numeric::converter<uint_16_t, int>::convert(apCfg->Port);
-		return PhysicalLayerFactory::GetTCPClientAsync(apCfg->Address, port);
+                TCPSettings tcp(apCfg->Address, boost::numeric::converter<uint_16_t, int>::convert(apCfg->Port));
+		return PhysicalLayerFactory::GetTCPClientAsync(tcp);
 	}
 
 	IPhysicalLayerAsyncFactory PhysicalLayerXMLFactory :: GetAsync(const APLXML_Base::TCPServer_t* apCfg)
 	{
-		uint_16_t port = boost::numeric::converter<uint_16_t, int>::convert(apCfg->Port);
-		return PhysicalLayerFactory::GetTCPServerAsync(apCfg->Endpoint, port);
+                TCPSettings tcp(apCfg->Endpoint, boost::numeric::converter<uint_16_t, int>::convert(apCfg->Port));
+		return PhysicalLayerFactory::GetTCPServerAsync(tcp);
 	}
 	
 	SerialSettings GetSerialSettings(const APLXML_Base::Serial_t* apCfg)

--- a/APLXML/PhysicalLayerXMLFactory.cpp
+++ b/APLXML/PhysicalLayerXMLFactory.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLXML/PhysicalLayerXMLFactory.h
+++ b/APLXML/PhysicalLayerXMLFactory.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLXML/SingleNodeSaver.h
+++ b/APLXML/SingleNodeSaver.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLXML/XMLConversion.cpp
+++ b/APLXML/XMLConversion.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLXML/XMLConversion.h
+++ b/APLXML/XMLConversion.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLXML/XML_APL.cpp
+++ b/APLXML/XML_APL.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLXML/XML_APL.h
+++ b/APLXML/XML_APL.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLXML/tinybinding.cpp
+++ b/APLXML/tinybinding.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/APLXML/tinybinding.h
+++ b/APLXML/tinybinding.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/APDU.cpp
+++ b/DNP3/APDU.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -118,7 +118,7 @@ namespace apl { namespace dnp {
 		assert(mpAppHeader != NULL);
 		assert(mpAppHeader->GetType() == AHT_RESPONSE);
 		/*if(mpAppHeader == NULL || mpAppHeader->GetType() != AHT_RESPONSE)
-		{ throw Exception(LOCATION, "IIN only valid with resposne header"); }*/
+		{ throw Exception(LOCATION, "IIN only valid with response header"); }*/
 
 		static_cast<ResponseHeader*>(mpAppHeader)->SetIIN(mBuffer, arIIN);
 	}
@@ -404,7 +404,7 @@ namespace apl { namespace dnp {
 		size_t count = (requested < maxObjects) ? requested : maxObjects;
 		size_t stop = aStart+count-1;
 
-		//we're commited to writing some data, so proceed
+		//we're committed to writing some data, so proceed
 		byte_t* pHeaderPos = mBuffer+mFragmentSize;
 		pHdr->Set(pHeaderPos, apObj->GetGroup(), apObj->GetVariation(), aCode);
 		byte_t* pPos = pHeaderPos+pHdr->GetSize();
@@ -436,7 +436,7 @@ namespace apl { namespace dnp {
 		size_t count = (requested < maxObjects) ? requested : maxObjects;
 		size_t stop = aStart+count-1;
 
-		//we're commited to writing some data, so proceed
+		//we're committed to writing some data, so proceed
 		byte_t* pHeaderPos = mBuffer+mFragmentSize;
 		pHdr->Set(pHeaderPos, apObj->GetGroup(), apObj->GetVariation(), aCode);
 		byte_t* pPos = pHeaderPos+pHdr->GetSize();
@@ -524,7 +524,7 @@ namespace apl { namespace dnp {
 		size_t data_size = count*obj_plus_prefix_size;
 		byte_t* pHeaderPos = mBuffer+mFragmentSize;
 
-		//commited to writing at this point, so set the header
+		//committed to writing at this point, so set the header
 		pHdr->Set(pHeaderPos, aGrp, aVar, aQual);
 		pHdr->SetCount(pHeaderPos, count);
 		mFragmentSize += pHdr->GetSize();
@@ -641,7 +641,7 @@ namespace apl { namespace dnp {
 		}
 		catch(Exception)
 		{
-			oss << " Malformed header data preceeds";
+			oss << " Malformed header data precedes";
 		}	
 
 		oss << ", Size: " << this->Size();

--- a/DNP3/APDU.h
+++ b/DNP3/APDU.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -81,7 +81,7 @@ namespace apl { namespace dnp {
 
 			IINField GetIIN() const;  // throws an exception if FUNC != RSP or UNSOL
 
-			//Overloaed helper that allows you to directly set the control values
+			//Overloaded helper that allows you to directly set the control values
 			void SetControl(bool aFIR, bool aFIN, bool aCON = false, bool aUNS = false, int aSEQ = 0)
 			{
 				AppControlField f(aFIR, aFIN, aCON, aUNS, aSEQ);

--- a/DNP3/APDUConstants.cpp
+++ b/DNP3/APDUConstants.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -71,7 +71,7 @@ std::string ToString(FunctionCodes aCode)
 		case(FC_SAVE_CONFIGURATION): return "Save Config";
 		case(FC_ENABLE_UNSOLICITED): return "Enable Unsol";
 		case(FC_DISABLE_UNSOLICITED): return "Disable Unsol";
-		case(FC_ASSIGN_CLASS): return "Assign Classs";
+		case(FC_ASSIGN_CLASS): return "Assign Class";
 		case(FC_DELAY_MEASURE): return "Delay Measure";
 		case(FC_RECORD_TIME): return "Record Time";
 

--- a/DNP3/APDUConstants.h
+++ b/DNP3/APDUConstants.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AppChannelStates.cpp
+++ b/DNP3/AppChannelStates.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AppChannelStates.h
+++ b/DNP3/AppChannelStates.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AppConfig.h
+++ b/DNP3/AppConfig.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AppHeader.cpp
+++ b/DNP3/AppHeader.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AppHeader.h
+++ b/DNP3/AppHeader.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AppLayerChannel.cpp
+++ b/DNP3/AppLayerChannel.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AppLayerChannel.h
+++ b/DNP3/AppLayerChannel.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -37,7 +37,7 @@ struct AppControlField;
 
 /**  The application layer contains two virtual channels, one for
 	 solicited and unsolicited communication. Each channel has a sequence
-	 number and some state associated with wether it is sending, waiting
+	 number and some state associated with whether it is sending, waiting
 	 for a response, etc
 */
 class AppLayerChannel : public Loggable
@@ -61,7 +61,7 @@ class AppLayerChannel : public Loggable
 	/// Resets the channel to the initial state
 	void Reset();
 
-	/// send, wether a response is expected is implicit based on func code
+	/// send, whether a response is expected is implicit based on func code
 	void Send(APDU&, size_t aNumRetry);
 	void Cancel();
 

--- a/DNP3/AsyncAppInterfaces.cpp
+++ b/DNP3/AsyncAppInterfaces.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncAppInterfaces.h
+++ b/DNP3/AsyncAppInterfaces.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -48,7 +48,7 @@ class IAsyncAppLayer
 
 		OnLowerLayerDown() - The transaction failed because the lower layer went down.
 
-		OnSendSuccess() - The data was transmitted succesfully and valid confirmation
+		OnSendSuccess() - The data was transmitted successfully and valid confirmation
 		was received within the timeout (if requested)
 	*/
 	virtual void SendResponse(APDU&) = 0;
@@ -56,23 +56,23 @@ class IAsyncAppLayer
 	/** Start an unsolicited transaction with optional confirmation and retries. This
 		sequence is almost identical to a response transaction.
 
-		FIR and FIN must both be set for unsolcited responses since they cannot
+		FIR and FIN must both be set for unsolicited responses since they cannot
 		be multifragmented.
 
-		A callback to one of the following is gauranteed:
+		A callback to one of the following is guaranteed:
 
 		OnFailure() - The transaction failed, either because the send failed or
 		the confirmation timed out.
 
 		OnLowerLayerDown() - The transaction failed because the lower layer went down.
 
-		OnSendSucces() - The data was transmitted succesfully and valid confirmation
+		OnSendSucces() - The data was transmitted successfully and valid confirmation
 		was received within the timeout (if requested)
 	*/
 	virtual void SendUnsolicited(APDU&) = 0;
 
 	/** Start a send transaction with optional confirmation and retries,
-		that should result in a resposne.
+		that should result in a response.
 
 		Callbacks are as follows:
 
@@ -96,7 +96,7 @@ class IAsyncAppLayer
 		Cancel a running response transaction. The outstation must still wait for an OnFailure()
 		from the application layer before proceeding with another response.
 
-		This is necessary to implement the behavior decribed in in DNP3Spec-V2-Part1-ApplicationLayer:
+		This is necessary to implement the behavior described in in DNP3Spec-V2-Part1-ApplicationLayer:
 
 		4.2.1 - ReadRules - Rule 1
 	*/

--- a/DNP3/AsyncAppLayer.cpp
+++ b/DNP3/AsyncAppLayer.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -265,7 +265,7 @@ void AsyncAppLayer::OnRequest(const AppControlField& arCtrl, APDU& arAPDU)
 }
 
 /////////////////////////////
-// Helperss
+// Helpers
 /////////////////////////////
 
 void AsyncAppLayer::QueueConfirm(bool aUnsol, int aSeq)

--- a/DNP3/AsyncAppLayer.h
+++ b/DNP3/AsyncAppLayer.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncDatabase.cpp
+++ b/DNP3/AsyncDatabase.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -192,7 +192,7 @@ namespace apl { namespace dnp {
 	}
 	
 	//////////////////////////////////////////////////////////////////////////////
-	// IDataObserver interfae - Private NVII functions - 
+	// IDataObserver interface - Private NVII functions - 
 	//////////////////////////////////////////////////////////////////////////////
 
 	void AsyncDatabase::_Update(const apl::Binary& arPoint, size_t aIndex)

--- a/DNP3/AsyncDatabase.h
+++ b/DNP3/AsyncDatabase.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncDatabaseInterfaces.h
+++ b/DNP3/AsyncDatabaseInterfaces.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncEventBufferBase.h
+++ b/DNP3/AsyncEventBufferBase.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -40,7 +40,7 @@ namespace apl { namespace dnp {
 
 		/**
 			Adds an event to the buffer, tracking insertion order. Calls
-			_Update which can be overriden to do special types of insertion.
+			_Update which can be overridden to do special types of insertion.
 
 			@param arVal Event update to add the to the buffer
 			@param aClass Class of the measurement

--- a/DNP3/AsyncEventBuffers.h
+++ b/DNP3/AsyncEventBuffers.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncLinkLayer.cpp
+++ b/DNP3/AsyncLinkLayer.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -73,12 +73,12 @@ bool AsyncLinkLayer::Validate(bool aIsMaster, uint_16_t aSrc, uint_16_t aDest)
 	}
 
 	if(aDest != mCONFIG.LocalAddr) {
-		ERROR_BLOCK(LEV_WARNING, "Frame for unknown destintation", DLERR_UNKNOWN_DESTINATION);
+		ERROR_BLOCK(LEV_WARNING, "Frame for unknown destination", DLERR_UNKNOWN_DESTINATION);
 		return false;
 	}
 
 	if(aSrc != mCONFIG.RemoteAddr) {
-		ERROR_BLOCK(LEV_WARNING, "Frame from unknwon source", DLERR_UNKNOWN_SOURCE);
+		ERROR_BLOCK(LEV_WARNING, "Frame from unknown source", DLERR_UNKNOWN_SOURCE);
 		return false;
 	}
 

--- a/DNP3/AsyncLinkLayer.h
+++ b/DNP3/AsyncLinkLayer.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncLinkLayerRouter.cpp
+++ b/DNP3/AsyncLinkLayerRouter.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncLinkLayerRouter.h
+++ b/DNP3/AsyncLinkLayerRouter.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncMaster.cpp
+++ b/DNP3/AsyncMaster.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncMaster.h
+++ b/DNP3/AsyncMaster.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncMasterStack.cpp
+++ b/DNP3/AsyncMasterStack.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncMasterStack.h
+++ b/DNP3/AsyncMasterStack.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncMasterStates.cpp
+++ b/DNP3/AsyncMasterStates.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncMasterStates.h
+++ b/DNP3/AsyncMasterStates.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncPort.cpp
+++ b/DNP3/AsyncPort.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncPort.h
+++ b/DNP3/AsyncPort.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncResponseContext.cpp
+++ b/DNP3/AsyncResponseContext.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncResponseContext.h
+++ b/DNP3/AsyncResponseContext.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -132,7 +132,7 @@ class AsyncResponseContext : public Loggable
 	{
 		IterRecord() : pObject(NULL) {}
 
-		typename StaticIter<T>::Type first;				/// Begining of iteration
+		typename StaticIter<T>::Type first;				/// Beginning of iteration
 		typename StaticIter<T>::Type last;				/// Last element of iteration
 		StreamObject<typename T::MeasType>* pObject;	/// Type to use to write
 	};

--- a/DNP3/AsyncSlave.cpp
+++ b/DNP3/AsyncSlave.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -175,7 +175,7 @@ void AsyncSlave::FlushDeferredEvents()
 	}
 
 	// if an unsol timer expiration was Deferred by a state,
-	// this action might cause an unsolicted response to be 
+	// this action might cause an unsolicited response to be 
 	// generated
 	if(mpState->AcceptsDeferredUnsolExpiration() && mDeferredUnsol) {
 		mDeferredUnsol = false;

--- a/DNP3/AsyncSlave.h
+++ b/DNP3/AsyncSlave.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -120,17 +120,17 @@ class AsyncSlave : public Loggable, public IAsyncAppUser
 	int mSequence;							/// control sequence
 	CommandResponseQueue mRspQueue;			/// how command responses are received
 	AS_Base* mpState;						/// current state for the state pattern
-	SlaveConfig mConfig;					/// houses the configurable paramters of the outstation
+	SlaveConfig mConfig;					/// houses the configurable parameters of the outstation
 	SlaveResponseTypes mRspTypes;			/// converts the group/var in the config to dnp singletons
 
-	ITimer* mpUnsolTimer;					/// timer for sending unsol responsess
+	ITimer* mpUnsolTimer;					/// timer for sending unsol responses
 
 	IINField mIIN;							/// IIN bits that persist between requests (i.e. NeedsTime/Restart/Etc)
 	IINField mRspIIN;						/// Transient IIN bits that get merged before a response is issued
 	APDU mResponse;							/// APDU used to form responses
 	APDU mRequest;							/// APDU used to save Deferred requests
 	SequenceInfo mSeqInfo;
-	APDU mUnsol;							/// APDY used to form unsol respones
+	APDU mUnsol;							/// APDY used to form unsol responses
 	AsyncResponseContext mRspContext;		/// Used to track and construct response fragments
 
 	bool mHaveLastRequest;
@@ -150,7 +150,7 @@ class AsyncSlave : public Loggable, public IAsyncAppUser
 	bool mStartupNullUnsol;					/// Tracks whether the device has completed the NULL unsol startup message
 
 	void OnDataUpdate();					/// internal event dispatched when user code commits an update to mChangeBuffer
-	void OnUnsolTimerExpiration();			/// internal event dispatched when the unsolicted pack/retry timer expires
+	void OnUnsolTimerExpiration();			/// internal event dispatched when the unsolicited pack/retry timer expires
 
 	void ConfigureAndSendSimpleResponse();
 	void Send(APDU&);

--- a/DNP3/AsyncSlaveEventBuffer.cpp
+++ b/DNP3/AsyncSlaveEventBuffer.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncSlaveEventBuffer.h
+++ b/DNP3/AsyncSlaveEventBuffer.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncSlaveStack.cpp
+++ b/DNP3/AsyncSlaveStack.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncSlaveStack.h
+++ b/DNP3/AsyncSlaveStack.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncSlaveStates.cpp
+++ b/DNP3/AsyncSlaveStates.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -61,7 +61,7 @@ void AS_Base::OnDataUpdate(AsyncSlave* c)
 	c->mDeferredUpdate = true;
 }
 
-/// by default, the unsol timer expiration is deferd until it can be handled
+/// by default, the unsol timer expiration is deferred until it can be handled
 void AS_Base::OnUnsolExpiration(AsyncSlave* c)
 {
 	c->mDeferredUnsol = true;
@@ -307,7 +307,7 @@ void AS_WaitForUnsolSuccess::OnUnsolSendSuccess(AsyncSlave* c)
 
 void AS_WaitForUnsolSuccess::OnRequest(AsyncSlave* c, const APDU& arAPDU, SequenceInfo aSeqInfo)
 {
-	if(arAPDU.GetFunction() == FC_READ) { //read requests should be defered until after the unsol
+	if(arAPDU.GetFunction() == FC_READ) { //read requests should be deferred until after the unsol
 		c->mRequest = arAPDU;
 		c->mSeqInfo = aSeqInfo;
 		c->mDeferredRequest = true;

--- a/DNP3/AsyncSlaveStates.h
+++ b/DNP3/AsyncSlaveStates.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncStack.cpp
+++ b/DNP3/AsyncStack.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncStack.h
+++ b/DNP3/AsyncStack.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncStackManager.cpp
+++ b/DNP3/AsyncStackManager.cpp
@@ -58,14 +58,14 @@ AsyncStackManager::~AsyncStackManager()
 std::vector<std::string> AsyncStackManager::GetStackNames() { return GetKeys<PortMap, string>(mStackToPort); }
 std::vector<std::string> AsyncStackManager::GetPortNames()  {  return GetKeys<PortMap, string>(mPortToPort); }
 
-void AsyncStackManager::AddTCPClient(const std::string& arName, PhysLayerSettings aSettings, const std::string& arAddr, uint_16_t aPort)
+void AsyncStackManager::AddTCPClient(const std::string& arName, PhysLayerSettings aSettings, TCPSettings aTcp)
 {	
-	mMgr.AddTCPClient(arName, aSettings, arAddr, aPort);
+	mMgr.AddTCPClient(arName, aSettings, aTcp);
 }
 
-void AsyncStackManager::AddTCPServer(const std::string& arName, PhysLayerSettings aSettings, const std::string& arEndpoint, uint_16_t aPort)
+void AsyncStackManager::AddTCPServer(const std::string& arName, PhysLayerSettings aSettings, TCPSettings aTcp)
 {	
-	mMgr.AddTCPServer(arName, aSettings, arEndpoint, aPort);
+	mMgr.AddTCPServer(arName, aSettings, aTcp);
 }
 
 void AsyncStackManager::AddSerial(const std::string& arName, PhysLayerSettings aSettings, SerialSettings aSerial)

--- a/DNP3/AsyncStackManager.cpp
+++ b/DNP3/AsyncStackManager.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncStackManager.h
+++ b/DNP3/AsyncStackManager.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -50,7 +50,7 @@ struct SlaveStackConfig;
 struct MasterStackConfig;
 
 /**
-	The interface for C++ projects for dnp3. Provides aninterface for starting/stopping
+	The interface for C++ projects for dnp3. Provides an interface for starting/stopping
 	master/slave protocol stacks. Any method may be called while the system is running.
 	Methods should only be called from a single thread at at a time.
 */
@@ -119,7 +119,7 @@ class AsyncStackManager : private Threadable, private Loggable
 		/// @return a vector of all the port names
 		std::vector<std::string> GetPortNames();
 
-		/// Start the thead if it isn't running
+		/// Start the thread if it isn't running
 		void Start();
 
 		/// Stop the thread, doesn't delete anything until the stack manager destructs

--- a/DNP3/AsyncStackManager.h
+++ b/DNP3/AsyncStackManager.h
@@ -67,10 +67,10 @@ class AsyncStackManager : private Threadable, private Loggable
 		// All the io_service marshalling now occurs here. It's now safe to add/remove while the manager is running.
 
 		/// Adds a TCPClient port, excepts if the port already exists
-		void AddTCPClient(const std::string& arName, PhysLayerSettings, const std::string& arAddr, uint_16_t aPort);
+		void AddTCPClient(const std::string& arName, PhysLayerSettings, TCPSettings);
 
 		/// Adds a TCPServer port, excepts if the port already exists
-		void AddTCPServer(const std::string& arName, PhysLayerSettings, const std::string& arEndpoint, uint_16_t aPort);
+		void AddTCPServer(const std::string& arName, PhysLayerSettings, TCPSettings);
 
 		/// Adds a Serial port, excepts if the port already exists
 		void AddSerial(const std::string& arName, PhysLayerSettings, SerialSettings);

--- a/DNP3/AsyncTransportLayer.cpp
+++ b/DNP3/AsyncTransportLayer.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/AsyncTransportLayer.h
+++ b/DNP3/AsyncTransportLayer.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/BufferSetTypes.h
+++ b/DNP3/BufferSetTypes.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/CTOHistory.h
+++ b/DNP3/CTOHistory.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/ClassCounter.cpp
+++ b/DNP3/ClassCounter.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/ClassCounter.h
+++ b/DNP3/ClassCounter.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/ClassMask.h
+++ b/DNP3/ClassMask.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/ControlTasks.cpp
+++ b/DNP3/ControlTasks.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/ControlTasks.h
+++ b/DNP3/ControlTasks.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/DNPCommandMaster.cpp
+++ b/DNP3/DNPCommandMaster.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/DNPCommandMaster.h
+++ b/DNP3/DNPCommandMaster.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/DNPConstants.h
+++ b/DNP3/DNPConstants.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/DNPCrc.cpp
+++ b/DNP3/DNPCrc.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/DNPCrc.h
+++ b/DNP3/DNPCrc.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/DNPDatabaseTypes.h
+++ b/DNP3/DNPDatabaseTypes.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -46,7 +46,7 @@ struct PointInfoBase
 
 	PointInfoBase() : mClass(PC_CLASS_0) {}
 
-	T mValue;						/// current measurment (i.e. Binary, Analog, etc)
+	T mValue;						/// current measurement (i.e. Binary, Analog, etc)
 	PointClass mClass;				/// class of the point (PC_CLASS<0-3>)
 	size_t mIndex;					/// index of the measurement
 

--- a/DNP3/DNPExceptions.h
+++ b/DNP3/DNPExceptions.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/DNPFromStream.h
+++ b/DNP3/DNPFromStream.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -25,7 +25,7 @@
 #include <iostream>
 
 #ifdef APL_PLATFORM_WIN
-//disable the type converstion warnings
+//disable the type conversion warnings
 #pragma warning ( push )
 #pragma warning ( disable : 4244 )
 #endif
@@ -39,7 +39,7 @@ namespace apl { namespace dnp {
 
 	/** Templates for read dnp3 data types from stream.
 		Used in the dnp3 object definitions to define how
-		they deserialize themeselves.
+		they deserialize themselves.
 	*/
 	class DNPFromStream
 	{
@@ -143,7 +143,7 @@ namespace apl { namespace dnp {
 }}
 
 #ifdef APL_PLATFORM_WIN
-//disable thes type converstion warnings
+//disable these type conversion warnings
 #pragma warning ( pop )
 #endif
 

--- a/DNP3/DNPToStream.h
+++ b/DNP3/DNPToStream.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -26,7 +26,7 @@
 //#include "Objects.h"
 
 #ifdef APL_PLATFORM_WIN
-//disable the type converstion warnings
+//disable the type conversion warnings
 #pragma warning ( push )
 #pragma warning ( disable : 4244 )
 #endif
@@ -144,7 +144,7 @@ namespace apl { namespace dnp {
 }}
 
 #ifdef APL_PLATFORM_WIN
-//disable the type converstion warnings
+//disable the type conversion warnings
 #pragma warning ( pop )
 #endif
 

--- a/DNP3/DataPoll.cpp
+++ b/DNP3/DataPoll.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/DataPoll.h
+++ b/DNP3/DataPoll.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/DeviceTemplate.cpp
+++ b/DNP3/DeviceTemplate.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/DeviceTemplate.h
+++ b/DNP3/DeviceTemplate.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/DeviceTemplateTypes.h
+++ b/DNP3/DeviceTemplateTypes.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/EventTypes.h
+++ b/DNP3/EventTypes.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/HeaderReadIterator.cpp
+++ b/DNP3/HeaderReadIterator.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/HeaderReadIterator.h
+++ b/DNP3/HeaderReadIterator.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -74,7 +74,7 @@ namespace apl { namespace dnp {
 		ObjectBase* mpObjectBase;
 	};
 
-	/// An interator that clients can use to loop over the object headers in an APDU
+	/// An iterator that clients can use to loop over the object headers in an APDU
 	class HeaderReadIterator
 	{
 		friend class APDU;

--- a/DNP3/IFrameSink.h
+++ b/DNP3/IFrameSink.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/ILinkContext.h
+++ b/DNP3/ILinkContext.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/ILinkRouter.h
+++ b/DNP3/ILinkRouter.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/IndexedWriteIterator.cpp
+++ b/DNP3/IndexedWriteIterator.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -67,7 +67,7 @@ IndexedWriteIterator::IndexMode IndexedWriteIterator::GetIndexMode(QualifierCode
 			return IM_NONE;
 
 		default:
-			throw Exception(LOCATION, "Illegal qualifer for packed indexed");
+			throw Exception(LOCATION, "Illegal qualifier for packed indexed");
 	}
 }
 
@@ -99,7 +99,7 @@ void IndexedWriteIterator::SetIndex(size_t aIndex)
 
 const IndexedWriteIterator& IndexedWriteIterator::operator++()
 {
-	if(this->IsEnd()) throw apl::InvalidStateException(LOCATION, "End of iterattion");
+	if(this->IsEnd()) throw apl::InvalidStateException(LOCATION, "End of iteration");
 	if(!mIndexSet) throw apl::InvalidStateException(LOCATION, "Index has not been set");
 
 	++mIndex;

--- a/DNP3/IndexedWriteIterator.h
+++ b/DNP3/IndexedWriteIterator.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/LinkConfig.h
+++ b/DNP3/LinkConfig.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/LinkFrame.cpp
+++ b/DNP3/LinkFrame.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/LinkFrame.h
+++ b/DNP3/LinkFrame.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -97,7 +97,7 @@ class LinkFrame
 	/** @return String representation of the frame */
 	std::string ToString() const;
 
-	/** Validates FT3 user data integriry
+	/** Validates FT3 user data integrity
 		@param apBody Beginning of the FT3 user data
 		@param aLength Number of user bytes to verify, not user + crc.
 		@return True if the body CRC is correct */

--- a/DNP3/LinkHeader.cpp
+++ b/DNP3/LinkHeader.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/LinkHeader.h
+++ b/DNP3/LinkHeader.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/LinkLayerConstants.cpp
+++ b/DNP3/LinkLayerConstants.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/LinkLayerConstants.h
+++ b/DNP3/LinkLayerConstants.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -53,7 +53,7 @@ namespace apl { namespace dnp {
 
 	/** These func codes are a little different then those defined in the specification for the following reason.
 		For simplicity the PRM bit is included to make the Pri-To-Sec and Sec-To-Pri codes non-overlapping
-		This is much simplier and for all intents and purposes you don't have to deal with the PRM bit anymore.
+		This is much simpler and for all intents and purposes you don't have to deal with the PRM bit anymore.
 
 		No implementation of function code 1:
 

--- a/DNP3/LinkLayerReceiver.cpp
+++ b/DNP3/LinkLayerReceiver.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/LinkLayerReceiver.h
+++ b/DNP3/LinkLayerReceiver.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/LinkReceiverStates.cpp
+++ b/DNP3/LinkReceiverStates.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/LinkReceiverStates.h
+++ b/DNP3/LinkReceiverStates.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/MasterConfig.h
+++ b/DNP3/MasterConfig.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -63,7 +63,7 @@ struct MasterConfig
 	/// If true, the master will enable/disable unsol on startup
 	bool DoUnsolOnStartup;
 
-	/// If DoUnsolOnStartup == true, the master will use this bit to decide wether to enable (true) or disable (false)
+	/// If DoUnsolOnStartup == true, the master will use this bit to decide whether to enable (true) or disable (false)
 	bool EnableUnsol;
 
 	///	Bitwise mask used determine which classes are enabled/disabled for unsol

--- a/DNP3/MasterConfigTypes.h
+++ b/DNP3/MasterConfigTypes.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/MasterSchedule.cpp
+++ b/DNP3/MasterSchedule.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/MasterSchedule.h
+++ b/DNP3/MasterSchedule.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/MasterStackConfig.h
+++ b/DNP3/MasterStackConfig.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/MasterTaskBase.cpp
+++ b/DNP3/MasterTaskBase.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/MasterTaskBase.h
+++ b/DNP3/MasterTaskBase.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/ObjectHeader.cpp
+++ b/DNP3/ObjectHeader.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/ObjectHeader.h
+++ b/DNP3/ObjectHeader.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -28,7 +28,7 @@
 
 #include <assert.h>
 
-//irratating windows macro interferes with the <limits> numeric_limits<T>::max()
+//irritating windows macro interferes with the <limits> numeric_limits<T>::max()
 #undef max
 
 

--- a/DNP3/ObjectHeader.h
+++ b/DNP3/ObjectHeader.h
@@ -168,7 +168,7 @@ namespace apl { namespace dnp {
 	template <class T, ObjectHeaderTypes U>
 	CountHeader<T,U> CountHeader<T,U>::mInstance;
 
-	//Typedefs so you don't have to direcly use the templates
+	//Typedefs so you don't have to directly use the templates
 	typedef RangedHeader<apl::UInt8, OHT_RANGED_2_OCTET>	Ranged2OctetHeader;
 	typedef RangedHeader<apl::UInt16LE, OHT_RANGED_4_OCTET> Ranged4OctetHeader;
 	typedef RangedHeader<apl::UInt32LE, OHT_RANGED_8_OCTET> Ranged8OctetHeader;

--- a/DNP3/ObjectInterfaces.cpp
+++ b/DNP3/ObjectInterfaces.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/ObjectInterfaces.h
+++ b/DNP3/ObjectInterfaces.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/ObjectReadIterator.cpp
+++ b/DNP3/ObjectReadIterator.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/ObjectReadIterator.h
+++ b/DNP3/ObjectReadIterator.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/ObjectWriteIterator.cpp
+++ b/DNP3/ObjectWriteIterator.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -47,7 +47,7 @@ mObjectSize(aObjectSize)
 
 const ObjectWriteIterator& ObjectWriteIterator::operator++()
 {
-	if(this->IsEnd()) throw apl::InvalidStateException(LOCATION, "End of iterattion");
+	if(this->IsEnd()) throw apl::InvalidStateException(LOCATION, "End of iteration");
 
 	++mIndex;
 	mpPos += mObjectSize;

--- a/DNP3/ObjectWriteIterator.h
+++ b/DNP3/ObjectWriteIterator.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/Objects.cpp
+++ b/DNP3/Objects.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/Objects.h
+++ b/DNP3/Objects.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/PointClass.cpp
+++ b/DNP3/PointClass.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/PointClass.h
+++ b/DNP3/PointClass.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/PriLinkLayerStates.cpp
+++ b/DNP3/PriLinkLayerStates.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -165,4 +165,4 @@ void PLLS_ConfDataWait::OnTimeout(AsyncLinkLayer* apLL)
 	}
 }
 
-}} //end namepsace
+}} //end namespace

--- a/DNP3/PriLinkLayerStates.h
+++ b/DNP3/PriLinkLayerStates.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -98,7 +98,7 @@ namespace apl { namespace dnp {
 
 
 
-}} //end namepsace
+}} //end namespace
 
 
 #endif

--- a/DNP3/ResponseLoader.cpp
+++ b/DNP3/ResponseLoader.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/ResponseLoader.h
+++ b/DNP3/ResponseLoader.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/SecLinkLayerStates.cpp
+++ b/DNP3/SecLinkLayerStates.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -94,4 +94,4 @@ void SLLS_Reset::ConfirmedUserData(AsyncLinkLayer* apLL, bool aFcb, const apl::b
 	}
 }
 
-}} //end namepsace
+}} //end namespace

--- a/DNP3/SecLinkLayerStates.h
+++ b/DNP3/SecLinkLayerStates.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -67,7 +67,7 @@ namespace apl { namespace dnp {
 		void ConfirmedUserData(AsyncLinkLayer*, bool aFcb, const apl::byte_t* apData, size_t aDataLength);
 	};
 
-}} //end namepsace
+}} //end namespace
 
 
 #endif

--- a/DNP3/SlaveConfig.cpp
+++ b/DNP3/SlaveConfig.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/SlaveConfig.h
+++ b/DNP3/SlaveConfig.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/SlaveResponseTypes.cpp
+++ b/DNP3/SlaveResponseTypes.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/SlaveResponseTypes.h
+++ b/DNP3/SlaveResponseTypes.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/SlaveStackConfig.h
+++ b/DNP3/SlaveStackConfig.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/SolicitedChannel.cpp
+++ b/DNP3/SolicitedChannel.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/SolicitedChannel.h
+++ b/DNP3/SolicitedChannel.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -25,7 +25,7 @@ namespace apl { namespace dnp {
 
 /**  The application layer contains two virtual channels, one for
 	 solicited and unsolicited communication. Each channel has a sequence
-	 number and some state associated with wether it is sending, waiting
+	 number and some state associated with whether it is sending, waiting
 	 for a response, etc
 */
 class SolicitedChannel : public AppLayerChannel
@@ -43,7 +43,7 @@ class SolicitedChannel : public AppLayerChannel
 
 	private:
 
-	// implement virtual memebers from AppLayerChannel
+	// implement virtual members from AppLayerChannel
 	void DoSendSuccess();
 	void DoFailure();
 };

--- a/DNP3/StackManager.cpp
+++ b/DNP3/StackManager.cpp
@@ -38,11 +38,11 @@ void StackManager::AddLogHook(ILogBase* apHook)
 StackManager::~StackManager() { delete mpImpl; delete mpLog; }
 
 //used for defining ports
-void StackManager::AddTCPClient(const std::string& arName, PhysLayerSettings s, const std::string& arAddr, uint_16_t aPort)
-{ mpImpl->AddTCPClient(arName, s, arAddr, aPort); }
+void StackManager::AddTCPClient(const std::string& arName, PhysLayerSettings s, TCPSettings aTcp)
+{ mpImpl->AddTCPClient(arName, s, aTcp); }
 
-void StackManager::AddTCPServer(const std::string& arName, PhysLayerSettings s, const std::string& arEndpoint, uint_16_t aPort)
-{ mpImpl->AddTCPServer(arName, s, arEndpoint, aPort); }
+void StackManager::AddTCPServer(const std::string& arName, PhysLayerSettings s, TCPSettings aTcp)
+{ mpImpl->AddTCPServer(arName, s, aTcp); }
 
 void StackManager::AddSerial(const std::string& arName, PhysLayerSettings s, SerialSettings aSerial)
 { mpImpl->AddSerial(arName, s, aSerial); }

--- a/DNP3/StackManager.cpp
+++ b/DNP3/StackManager.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/StackManager.h
+++ b/DNP3/StackManager.h
@@ -24,6 +24,7 @@
 #include <APL/CommandInterfaces.h>
 #include <APL/LogBase.h>
 #include <APL/SerialTypes.h>
+#include <APL/TCPTypes.h>
 
 #include <DNP3/MasterStackConfig.h>
 #include <DNP3/SlaveStackConfig.h>
@@ -49,8 +50,8 @@ class StackManager
 		StackManager(bool aAutoStart);
 		~StackManager();
 
-		void AddTCPClient(const std::string& arName, PhysLayerSettings aPhys, const std::string& arAddr, uint_16_t aPort);
-		void AddTCPServer(const std::string& arName, PhysLayerSettings  aPhys, const std::string& arEndpoint, uint_16_t aPort);
+		void AddTCPClient(const std::string& arName, PhysLayerSettings aPhys, TCPSettings aTcp);
+		void AddTCPServer(const std::string& arName, PhysLayerSettings aPhys, TCPSettings aTcp);
 		void AddSerial(const std::string& arName, PhysLayerSettings aPhys, SerialSettings aSerial);
 
 		ICommandAcceptor* AddMaster(const std::string& arPortName,

--- a/DNP3/StackManager.h
+++ b/DNP3/StackManager.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -39,7 +39,7 @@ namespace apl { namespace dnp {
 
 class AsyncStackManager;
 
-/** Wraps the AyncStackManger using the impl pattern. This makes it suiteable
+/** Wraps the AyncStackManger using the impl pattern. This makes it suitable
 	for wrapping with swig or for creating a header-only distribution
 	The functions do the exact same thing as their impl counterparts
 	*/

--- a/DNP3/StartupTasks.cpp
+++ b/DNP3/StartupTasks.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/StartupTasks.h
+++ b/DNP3/StartupTasks.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/TLS_Base.cpp
+++ b/DNP3/TLS_Base.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/TLS_Base.h
+++ b/DNP3/TLS_Base.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/TransportConstants.h
+++ b/DNP3/TransportConstants.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/TransportRx.cpp
+++ b/DNP3/TransportRx.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/TransportRx.h
+++ b/DNP3/TransportRx.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/TransportStates.cpp
+++ b/DNP3/TransportStates.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/TransportStates.h
+++ b/DNP3/TransportStates.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -57,7 +57,7 @@ namespace apl { namespace dnp {
 		void LowerLayerDown(AsyncTransportLayer*);
 	};
 
-}} //end namepsace
+}} //end namespace
 
 
 #endif

--- a/DNP3/TransportTx.cpp
+++ b/DNP3/TransportTx.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/TransportTx.h
+++ b/DNP3/TransportTx.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/UnsolicitedChannel.cpp
+++ b/DNP3/UnsolicitedChannel.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3/UnsolicitedChannel.h
+++ b/DNP3/UnsolicitedChannel.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
@@ -25,7 +25,7 @@ namespace apl { namespace dnp {
 
 /**  The application layer contains two virtual channels, one for
 	 solicited and unsolicited communication. Each channel has a sequence
-	 number and some state associated with wether it is sending, waiting
+	 number and some state associated with whether it is sending, waiting
 	 for a response, etc
 */
 class UnsolicitedChannel : public AppLayerChannel

--- a/DNP3Test/AppLayerTest.cpp
+++ b/DNP3Test/AppLayerTest.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/AppLayerTest.h
+++ b/DNP3Test/AppLayerTest.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/AsyncDatabaseTestObject.h
+++ b/DNP3Test/AsyncDatabaseTestObject.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/AsyncIntegrationTest.cpp
+++ b/DNP3Test/AsyncIntegrationTest.cpp
@@ -107,8 +107,9 @@ void AsyncIntegrationTest::AddStackPair(FilterLevel aLevel, size_t aNumPoints)
 	std::string server = oss.str() + " Server ";
 
 	PhysLayerSettings s(aLevel, 1000);
-	this->AddTCPClient(client, s, "127.0.0.1", port);
-	this->AddTCPServer(server, s, "127.0.0.1", port);
+	TCPSettings tcp("127.0.0.1", port);
+	this->AddTCPClient(client, s, tcp);
+	this->AddTCPServer(server, s, tcp);
 
 	{
 	MasterStackConfig cfg;

--- a/DNP3Test/AsyncIntegrationTest.cpp
+++ b/DNP3Test/AsyncIntegrationTest.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/AsyncIntegrationTest.h
+++ b/DNP3Test/AsyncIntegrationTest.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/AsyncLinkLayerRouterTest.cpp
+++ b/DNP3Test/AsyncLinkLayerRouterTest.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/AsyncLinkLayerRouterTest.h
+++ b/DNP3Test/AsyncLinkLayerRouterTest.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/AsyncLinkLayerTest.cpp
+++ b/DNP3Test/AsyncLinkLayerTest.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/AsyncLinkLayerTest.h
+++ b/DNP3Test/AsyncLinkLayerTest.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/AsyncMasterTestObject.cpp
+++ b/DNP3Test/AsyncMasterTestObject.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/AsyncMasterTestObject.h
+++ b/DNP3Test/AsyncMasterTestObject.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/AsyncSlaveTestObject.cpp
+++ b/DNP3Test/AsyncSlaveTestObject.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/AsyncSlaveTestObject.h
+++ b/DNP3Test/AsyncSlaveTestObject.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/AsyncStartupTeardownTest.cpp
+++ b/DNP3Test/AsyncStartupTeardownTest.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/AsyncStartupTeardownTest.cpp
+++ b/DNP3Test/AsyncStartupTeardownTest.cpp
@@ -37,7 +37,8 @@ void AsyncStartupTeardownTest::CreatePort(const std::string& arName, FilterLevel
 {
 	std::string name = arName + " router";
 	PhysLayerSettings s(aLevel, 1000);
-	mMgr.AddTCPClient(arName, s, "127.0.0.1", 30000);
+	TCPSettings tcp("127.0.0.1", 30000);
+	mMgr.AddTCPClient(arName, s, tcp);
 }
 
 void AsyncStartupTeardownTest::AddMaster(const std::string& arStackName, const std::string& arPortName, uint_16_t aLocalAddress, FilterLevel aLevel)

--- a/DNP3Test/AsyncStartupTeardownTest.h
+++ b/DNP3Test/AsyncStartupTeardownTest.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/DNPHelpers.cpp
+++ b/DNP3Test/DNPHelpers.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/DNPHelpers.h
+++ b/DNP3Test/DNPHelpers.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/LinkReceiverTest.h
+++ b/DNP3Test/LinkReceiverTest.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/MockAppUser.cpp
+++ b/DNP3Test/MockAppUser.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/MockAppUser.h
+++ b/DNP3Test/MockAppUser.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/MockAsyncAppLayer.cpp
+++ b/DNP3Test/MockAsyncAppLayer.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/MockAsyncAppLayer.h
+++ b/DNP3Test/MockAsyncAppLayer.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/MockFrameSink.cpp
+++ b/DNP3Test/MockFrameSink.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/MockFrameSink.h
+++ b/DNP3Test/MockFrameSink.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/ResponseLoaderTestObject.cpp
+++ b/DNP3Test/ResponseLoaderTestObject.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/ResponseLoaderTestObject.h
+++ b/DNP3Test/ResponseLoaderTestObject.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestAPDU.cpp
+++ b/DNP3Test/TestAPDU.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestAPDUWriting.cpp
+++ b/DNP3Test/TestAPDUWriting.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestAsyncAppLayer.cpp
+++ b/DNP3Test/TestAsyncAppLayer.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestAsyncDatabase.cpp
+++ b/DNP3Test/TestAsyncDatabase.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestAsyncEventBufferBase.cpp
+++ b/DNP3Test/TestAsyncEventBufferBase.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestAsyncEventBuffers.cpp
+++ b/DNP3Test/TestAsyncEventBuffers.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestAsyncIntegration.cpp
+++ b/DNP3Test/TestAsyncIntegration.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestAsyncLinkLayer.cpp
+++ b/DNP3Test/TestAsyncLinkLayer.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestAsyncLinkLayerRouter.cpp
+++ b/DNP3Test/TestAsyncLinkLayerRouter.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestAsyncMaster.cpp
+++ b/DNP3Test/TestAsyncMaster.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestAsyncSlave.cpp
+++ b/DNP3Test/TestAsyncSlave.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestAsyncSlaveEventBuffer.cpp
+++ b/DNP3Test/TestAsyncSlaveEventBuffer.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestAsyncTransportLayer.cpp
+++ b/DNP3Test/TestAsyncTransportLayer.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestAsyncTransportLoopback.cpp
+++ b/DNP3Test/TestAsyncTransportLoopback.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestAsyncTransportScalability.cpp
+++ b/DNP3Test/TestAsyncTransportScalability.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestCRC.cpp
+++ b/DNP3Test/TestCRC.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestLinkFrameDNP.cpp
+++ b/DNP3Test/TestLinkFrameDNP.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestLinkReceiver.cpp
+++ b/DNP3Test/TestLinkReceiver.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestObjects.cpp
+++ b/DNP3Test/TestObjects.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestResponseLoader.cpp
+++ b/DNP3Test/TestResponseLoader.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TestStartupTeardown.cpp
+++ b/DNP3Test/TestStartupTeardown.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TransportIntegrationStack.cpp
+++ b/DNP3Test/TransportIntegrationStack.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TransportIntegrationStack.h
+++ b/DNP3Test/TransportIntegrationStack.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TransportLoopbackTestObject.cpp
+++ b/DNP3Test/TransportLoopbackTestObject.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TransportLoopbackTestObject.h
+++ b/DNP3Test/TransportLoopbackTestObject.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TransportScalabilityTestObject.cpp
+++ b/DNP3Test/TransportScalabilityTestObject.cpp
@@ -46,7 +46,8 @@ mTimerSource(this->GetService())
 		ostringstream oss;
 		oss << "pair" << port;
 		Logger* pLogger = mpLogger->GetSubLogger(oss.str());
-		TransportStackPair* pPair = new TransportStackPair(aClientCfg, aServerCfg, pLogger, this->GetService(), &mTimerSource, port);
+		TCPSettings tcp("127.0.0.1", port);
+		TransportStackPair* pPair = new TransportStackPair(aClientCfg, aServerCfg, pLogger, this->GetService(), &mTimerSource, tcp);
 		mPairs.push_back(pPair);
 	}
 }

--- a/DNP3Test/TransportScalabilityTestObject.cpp
+++ b/DNP3Test/TransportScalabilityTestObject.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TransportScalabilityTestObject.h
+++ b/DNP3Test/TransportScalabilityTestObject.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TransportStackPair.cpp
+++ b/DNP3Test/TransportStackPair.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TransportStackPair.cpp
+++ b/DNP3Test/TransportStackPair.cpp
@@ -29,10 +29,10 @@ TransportStackPair::TransportStackPair(
 	Logger* apLogger,
 	boost::asio::io_service* apService,
 	ITimerSource* apTimerSrc,
-	uint_16_t aPort) :
+	TCPSettings aTcp) :
 
-mClient(apLogger->GetSubLogger("TCPClient"), apService, "127.0.0.1", aPort),
-mServer(apLogger->GetSubLogger("TCPServer"), apService, "127.0.0.1", aPort),
+mClient(apLogger->GetSubLogger("TCPClient"), apService, aTcp),
+mServer(apLogger->GetSubLogger("TCPServer"), apService, aTcp),
 mClientStack(apLogger->GetSubLogger("ClientStack"), apTimerSrc, &mClient, aClientCfg),
 mServerStack(apLogger->GetSubLogger("ServerStack"), apTimerSrc, &mServer, aServerCfg)
 {

--- a/DNP3Test/TransportStackPair.h
+++ b/DNP3Test/TransportStackPair.h
@@ -41,7 +41,7 @@ class TransportStackPair
 			Logger* apLogger,
 			boost::asio::io_service* apService,
 			ITimerSource* apTimerSrc,
-			uint_16_t aPort);
+			TCPSettings aTcp);
 
 		void Start();
 

--- a/DNP3Test/TransportStackPair.h
+++ b/DNP3Test/TransportStackPair.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TransportTestObject.cpp
+++ b/DNP3Test/TransportTestObject.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3Test/TransportTestObject.h
+++ b/DNP3Test/TransportTestObject.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3XML/XML_DNP3.cpp
+++ b/DNP3XML/XML_DNP3.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3XML/XML_DNP3.h
+++ b/DNP3XML/XML_DNP3.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3XML/XML_TestSet.cpp
+++ b/DNP3XML/XML_TestSet.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3XML/XML_TestSet.h
+++ b/DNP3XML/XML_TestSet.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3XML/XmlToConfig.cpp
+++ b/DNP3XML/XmlToConfig.cpp
@@ -47,13 +47,13 @@ namespace apl { namespace dnp {
 		{
 			TCPClient_t* pCfg = arList.TCPClientVector[i];
 			PhysLayerSettings s(aLevel, pCfg->OpenRetryMS);
-			arMgr.AddTCPClient(pCfg->Name, s, pCfg->Address, pCfg->Port);
+			arMgr.AddTCPClient(pCfg->Name, s, TCPSettings(pCfg->Address, pCfg->Port));
 		}
 		for (size_t i = 0; i < arList.TCPServerVector.size(); i++ )
 		{
 			TCPServer_t* pCfg = arList.TCPServerVector[i];
 			PhysLayerSettings s(aLevel, pCfg->OpenRetryMS);
-			arMgr.AddTCPServer(pCfg->Name, s, pCfg->Endpoint, pCfg->Port);
+			arMgr.AddTCPServer(pCfg->Name, s, TCPSettings(pCfg->Endpoint, pCfg->Port));
 		}
 		for (size_t i = 0; i < arList.SerialVector.size(); i++ )
 		{

--- a/DNP3XML/XmlToConfig.cpp
+++ b/DNP3XML/XmlToConfig.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/DNP3XML/XmlToConfig.h
+++ b/DNP3XML/XmlToConfig.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/SlaveDemo/DemoMain.cpp
+++ b/SlaveDemo/DemoMain.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/SlaveDemo/DemoMain.cpp
+++ b/SlaveDemo/DemoMain.cpp
@@ -65,7 +65,7 @@ int main(int argc, char* argv[])
 	// add a TCPServer to the manager on port 4999 with the name "tcpserver"
 	// The server will wait 3000 ms in between failed bind calls
 	// The server will *only* respond to connections on the loopback
-	mgr.AddTCPServer("tcpserver", PhysLayerSettings(LOG_LEVEL, 3000), "127.0.0.1", 4999);
+	mgr.AddTCPServer("tcpserver", PhysLayerSettings(LOG_LEVEL, 3000), TCPSettings("127.0.0.1", 4999));
 
 	// The master config object for a slave. The default are useable, but understaning the options are important
 	SlaveStackConfig stackConfig;

--- a/SlaveDemo/SlaveDemo.cpp
+++ b/SlaveDemo/SlaveDemo.cpp
@@ -26,7 +26,7 @@ namespace apl { namespace dnp {
 SlaveDemoBase::SlaveDemoBase(Logger* apLogger) : 
 Loggable(apLogger),
 IOService(),
-IOServiceThread(this->Get()),
+IOServiceThread(apLogger, this->Get()),
 mTimerSource(this->Get())
 {
 	// Start a timer that will do nothing but keep the boost asio service from returning when it has no work to do

--- a/SlaveDemo/SlaveDemo.cpp
+++ b/SlaveDemo/SlaveDemo.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/SlaveDemo/SlaveDemo.cpp
+++ b/SlaveDemo/SlaveDemo.cpp
@@ -24,7 +24,6 @@ using namespace std;
 namespace apl { namespace dnp {
 
 SlaveDemoBase::SlaveDemoBase(Logger* apLogger) : 
-Loggable(apLogger),
 IOService(),
 IOServiceThread(apLogger, this->Get()),
 mTimerSource(this->Get())

--- a/SlaveDemo/SlaveDemo.h
+++ b/SlaveDemo/SlaveDemo.h
@@ -40,7 +40,7 @@ namespace apl { namespace dnp {
 	This class takes care of all the plumbing and bingings between application code and the stack. 
 	Inherited clases on have to implement the ICommandHandler interface.
 */
-class SlaveDemoBase : protected Loggable, protected ICommandHandler, private IOService, public IOServiceThread
+class SlaveDemoBase : protected ICommandHandler, private IOService, public IOServiceThread
 {
 	public:
 	SlaveDemoBase(Logger* apLogger);

--- a/SlaveDemo/SlaveDemo.h
+++ b/SlaveDemo/SlaveDemo.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/AsyncPhysBaseTest.cpp
+++ b/TestAPL/AsyncPhysBaseTest.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/AsyncPhysBaseTest.h
+++ b/TestAPL/AsyncPhysBaseTest.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/AsyncPhysTestObject.cpp
+++ b/TestAPL/AsyncPhysTestObject.cpp
@@ -29,8 +29,8 @@ namespace apl {
 AsyncPhysTestObject::AsyncPhysTestObject(FilterLevel aLevel, bool aImmediate, bool aAutoRead) :
 AsyncTestObjectASIO(),
 LogTester(aImmediate),
-mTCPClient(mLog.GetLogger(aLevel,"TCPClient"), this->GetService(), "127.0.0.1", 50000),
-mTCPServer(mLog.GetLogger(aLevel,"TCPSever"), this->GetService(), "127.0.0.1", 50000),
+mTCPClient(mLog.GetLogger(aLevel,"TCPClient"), this->GetService(), TCPSettings("127.0.0.1", 50000)),
+mTCPServer(mLog.GetLogger(aLevel,"TCPSever"), this->GetService(), TCPSettings("127.0.0.1", 50000)),
 mClientAdapter(mLog.GetLogger(aLevel,"ClientAdapter"), &mTCPClient, aAutoRead),
 mServerAdapter(mLog.GetLogger(aLevel,"ServerAdapter"), &mTCPServer, aAutoRead),
 mClientUpper(mLog.GetLogger(aLevel,"MockUpperClient")),

--- a/TestAPL/AsyncPhysTestObject.cpp
+++ b/TestAPL/AsyncPhysTestObject.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/AsyncPhysTestObject.h
+++ b/TestAPL/AsyncPhysTestObject.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/AsyncSerialTestObject.cpp
+++ b/TestAPL/AsyncSerialTestObject.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/AsyncSerialTestObject.h
+++ b/TestAPL/AsyncSerialTestObject.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestASIO.cpp
+++ b/TestAPL/TestASIO.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestAsyncTask.cpp
+++ b/TestAPL/TestAsyncTask.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestCastLongLongDouble.cpp
+++ b/TestAPL/TestCastLongLongDouble.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestCommandQueue.cpp
+++ b/TestAPL/TestCommandQueue.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestCommandTypes.cpp
+++ b/TestAPL/TestCommandTypes.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestLocks.cpp
+++ b/TestAPL/TestLocks.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestLog.cpp
+++ b/TestAPL/TestLog.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestMisc.cpp
+++ b/TestAPL/TestMisc.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestPackingUnpacking.cpp
+++ b/TestAPL/TestPackingUnpacking.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestParsing.cpp
+++ b/TestAPL/TestParsing.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestPhysicalLayerAsyncBase.cpp
+++ b/TestAPL/TestPhysicalLayerAsyncBase.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestPhysicalLayerAsyncSerial.cpp
+++ b/TestAPL/TestPhysicalLayerAsyncSerial.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestPhysicalLayerAsyncTCP.cpp
+++ b/TestAPL/TestPhysicalLayerAsyncTCP.cpp
@@ -158,21 +158,22 @@ BOOST_AUTO_TEST_SUITE(PhysicalLayerAsyncTCPSuite)
 
 	BOOST_AUTO_TEST_CASE(Loopback)
 	{		
-		EventLog logserver;
+		EventLog serverLog;
+		Logger* serverLogger = serverLog.GetLogger(LEV_DEBUG, "server");			
 		boost::asio::io_service loopservice;
 		TimerSourceASIO timer_src(&loopservice);
-		PhysicalLayerAsyncTCPServer server(logserver.GetLogger(LEV_INFO, "server"), &loopservice, "127.0.0.1", 30000);
-		AsyncLoopback t(logserver.GetLogger(LEV_INFO, "loopback"), &server, &timer_src, LEV_WARNING, false);
-		IOServiceThread iost(&loopservice);				
+		PhysicalLayerAsyncTCPServer server(serverLog.GetLogger(LEV_INFO, "server"), &loopservice, "127.0.0.1", 30000);
+		AsyncLoopback t(serverLog.GetLogger(LEV_INFO, "loopback"), &server, &timer_src, LEV_WARNING, false);
+		IOServiceThread iost(serverLogger, &loopservice);				
 		t.Start();
 		iost.Start();
 
-		EventLog log;		
-		Logger* logger = log.GetLogger(LEV_DEBUG, "client");			
+		EventLog clientLog;		
+		Logger* clientLogger = clientLog.GetLogger(LEV_DEBUG, "client");			
 		AsyncTestObjectASIO test;
-		PhysicalLayerAsyncTCPClient client(logger, test.GetService(), "127.0.0.1", 30000);
-		LowerLayerToPhysAdapter adapter(logger, &client);
-		MockUpperLayer upper(logger);
+		PhysicalLayerAsyncTCPClient client(clientLogger, test.GetService(), "127.0.0.1", 30000);
+		LowerLayerToPhysAdapter adapter(clientLogger, &client);
+		MockUpperLayer upper(clientLogger);
 		adapter.SetUpperLayer(&upper);
 							
 		client.AsyncOpen();

--- a/TestAPL/TestPhysicalLayerAsyncTCP.cpp
+++ b/TestAPL/TestPhysicalLayerAsyncTCP.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestPhysicalLayerAsyncTCP.cpp
+++ b/TestAPL/TestPhysicalLayerAsyncTCP.cpp
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_SUITE(PhysicalLayerAsyncTCPSuite)
 		Logger* serverLogger = serverLog.GetLogger(LEV_DEBUG, "server");			
 		boost::asio::io_service loopservice;
 		TimerSourceASIO timer_src(&loopservice);
-		PhysicalLayerAsyncTCPServer server(serverLog.GetLogger(LEV_INFO, "server"), &loopservice, "127.0.0.1", 30000);
+		PhysicalLayerAsyncTCPServer server(serverLog.GetLogger(LEV_INFO, "server"), &loopservice, TCPSettings("127.0.0.1", 30000));
 		AsyncLoopback t(serverLog.GetLogger(LEV_INFO, "loopback"), &server, &timer_src, LEV_WARNING, false);
 		IOServiceThread iost(serverLogger, &loopservice);				
 		t.Start();
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_SUITE(PhysicalLayerAsyncTCPSuite)
 		EventLog clientLog;		
 		Logger* clientLogger = clientLog.GetLogger(LEV_DEBUG, "client");			
 		AsyncTestObjectASIO test;
-		PhysicalLayerAsyncTCPClient client(clientLogger, test.GetService(), "127.0.0.1", 30000);
+		PhysicalLayerAsyncTCPClient client(clientLogger, test.GetService(), TCPSettings("127.0.0.1", 30000));
 		LowerLayerToPhysAdapter adapter(clientLogger, &client);
 		MockUpperLayer upper(clientLogger);
 		adapter.SetUpperLayer(&upper);

--- a/TestAPL/TestQualityMasks.cpp
+++ b/TestAPL/TestQualityMasks.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestShiftableBuffer.cpp
+++ b/TestAPL/TestShiftableBuffer.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestSyncVar.cpp
+++ b/TestAPL/TestSyncVar.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestThreading.cpp
+++ b/TestAPL/TestThreading.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestTime.cpp
+++ b/TestAPL/TestTime.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestTimers.cpp
+++ b/TestAPL/TestTimers.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestTypes.cpp
+++ b/TestAPL/TestTypes.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestUtil.cpp
+++ b/TestAPL/TestUtil.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestAPL/TestXmlBinding.cpp
+++ b/TestAPL/TestXmlBinding.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestSet/StackHelpers.cpp
+++ b/TestSet/StackHelpers.cpp
@@ -34,7 +34,7 @@ namespace apl { namespace dnp {
 
 IPhysicalLayerAsync* FGetTerminalPhys(Logger* apLogger, boost::asio::io_service* apSrv, bool aRemote, apl::uint_16_t aRemotePort)
 {
-	if (aRemote) return PhysicalLayerFactory::FGetTCPServerAsync("0.0.0.0", aRemotePort, apSrv, apLogger);
+	if (aRemote) return PhysicalLayerFactory::FGetTCPServerAsync(TCPSettings("0.0.0.0", aRemotePort), apSrv, apLogger);
 	else return new PhysicalLayerIOStreamAsync(apLogger, apSrv);
 }
 

--- a/TestSet/StackHelpers.cpp
+++ b/TestSet/StackHelpers.cpp
@@ -43,7 +43,7 @@ StackBase::StackBase(const APLXML_Base::PhysicalLayerList_t& arList, FilterLevel
 	logToFile(&log, arLogFile),
 	pTermLogger(log.GetLogger(aLevel, "terminal")),	
 	mService(),
-	mTermThread(mService.Get()),
+	mTermThread(log.GetLogger(aLevel, "terminal"), mService.Get()),
 	mTimerSrc(mService.Get()),
 	pTermPhys(FGetTerminalPhys(pTermLogger, mTermThread.GetService(), aRemote, aRemotePort)),
 	fdo(),

--- a/TestSet/StackHelpers.cpp
+++ b/TestSet/StackHelpers.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestSet/StackHelpers.h
+++ b/TestSet/StackHelpers.h
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/TestSet/main.cpp
+++ b/TestSet/main.cpp
@@ -2,7 +2,7 @@
 // Licensed to Green Energy Corp (www.greenenergycorp.com) under one
 // or more contributor license agreements. See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  Green Enery Corp licenses this file
+// regarding copyright ownership.  Green Energy Corp licenses this file
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at

--- a/tools/install_scripts/boost/1_43/install-boost.sh
+++ b/tools/install_scripts/boost/1_43/install-boost.sh
@@ -21,7 +21,9 @@ INSTALL_DIR=$TOOLS_HOME/boostlib/boost_1_43
 echo "Boost will be installed to $INSTALL_DIR"
 
 if [ ! -e $TEMP_DIR/boost_1_43_0.tar.bz2 ]; then
-  wget -P $TEMP_DIR http://sourceforge.net/projects/boost/files/boost/1.43.0/boost_1_43_0.tar.bz2/download
+  # Make wget save the file with the expected name, even if we're redirected to some other document.
+  mkdir -p $TEMP_DIR
+  wget http://sourceforge.net/projects/boost/files/boost/1.43.0/boost_1_43_0.tar.bz2/download --output-document $TEMP_DIR/boost_1_43_0.tar.bz2
 fi
 
 cd $TEMP_DIR


### PR DESCRIPTION
Note: Issues below refer to those found on http://code.google.com/p/dnp3/issues/list .
- Issue #3 - Added support for per-connection TCP keepalive settings for POSIX systems.  Adding support for Win32 systems appears to be possible, but I am not a Windows developer so I have not implemented it.
- Issue #6 - The IOServiceThread no longer silently discards errors (by printing them to cout).  It logs them in the typical fashion.
- Issue #7 - PhysicalLayerAsyncTCPServer::DoOpen() no longer erroneously mucks with the mEndpoint member variable.
- Misc: Fixed many spelling errors and typos in both comments and log message text.
- Misc: Fixed a problem with the Boost 1.43 install script that could cause it to fail if wget was redirected when downloading the tarball.
